### PR TITLE
feat: validate store/add access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # upload-api
+
+Required environment variables:
+
+- `ACCESS_SERVICE_DID` - DID of the w3access service
+- `ACCESS_SERVICE_URL` - URL of the w3access service

--- a/api/access.js
+++ b/api/access.js
@@ -8,7 +8,7 @@ import { CAR, CBOR, HTTP } from '@ucanto/transport'
  * @param {URL} serviceURL URL of the Access service.
  * @returns {import('./service/types').AccessClient}
  */
-export function createAccess (issuer, serviceDID, serviceURL) {
+export function createAccessClient (issuer, serviceDID, serviceURL) {
   /** @type {import('@ucanto/server').ConnectionView<import('@web3-storage/access/types').Service>} */
   const conn = connect({
     id: serviceDID,

--- a/api/access.js
+++ b/api/access.js
@@ -1,0 +1,40 @@
+import { info } from '@web3-storage/access/capabilities/account'
+import { connect } from '@ucanto/client'
+import { CAR, CBOR, HTTP } from '@ucanto/transport'
+
+/**
+ * @param {import('@ucanto/interface').Signer} issuer
+ * @param {import('@ucanto/interface').Principal} serviceDID
+ * @param {URL} serviceURL
+ * @returns {import('./service/types').AccessClient}
+ */
+export function createAccess (issuer, serviceDID, serviceURL) {
+  const conn = connect({
+    id: serviceDID,
+    encoder: CAR,
+    decoder: CBOR,
+    channel: HTTP.open({
+      url: new URL(serviceURL),
+      method: 'POST'
+    })
+  })
+
+  return {
+    async verifyInvocation (invocation) {
+      if (!invocation.capabilities.length) return true
+      // if info capability is derivable from the passed capability, then we'll
+      // receive a response and know that the invocation issuer has verified
+      // themselves with w3access.
+      const res = await info
+        .invoke({
+          issuer,
+          audience: serviceDID,
+          // @ts-expect-error
+          with: invocation.capabilities[0].with,
+          proofs: [invocation]
+        })
+        .execute(conn)
+      return !res.error
+    }
+  }
+}

--- a/api/access.js
+++ b/api/access.js
@@ -1,6 +1,7 @@
 import { info } from '@web3-storage/access/capabilities/account'
 import { connect } from '@ucanto/client'
 import { CAR, CBOR, HTTP } from '@ucanto/transport'
+import fetch from '@web-std/fetch'
 
 /**
  * @param {import('@ucanto/interface').Signer} issuer Issuer of UCAN invocations to the Access service.
@@ -14,7 +15,7 @@ export function createAccessClient (issuer, serviceDID, serviceURL) {
     id: serviceDID,
     encoder: CAR,
     decoder: CBOR,
-    channel: HTTP.open({ url: serviceURL, method: 'POST' })
+    channel: HTTP.open({ url: serviceURL, method: 'POST', fetch })
   })
 
   return {

--- a/api/buckets/car-store.js
+++ b/api/buckets/car-store.js
@@ -5,8 +5,7 @@ import { S3Client, HeadObjectCommand } from '@aws-sdk/client-s3'
  *
  * @param {string} region
  * @param {string} bucketName
- * @param {object} [options]
- * @param {string} [options.endpoint] - needed for testing
+ * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
  */
 export function createCarStore (region, bucketName, options = {}) {
   const s3client = new S3Client({

--- a/api/functions/ucan-invocation-router.js
+++ b/api/functions/ucan-invocation-router.js
@@ -4,7 +4,7 @@ import * as CBOR from '@ucanto/transport/cbor'
 import { DID } from '@ucanto/core'
 
 import getServiceDid from '../authority.js'
-import { createAccess } from '../access.js'
+import { createAccessClient } from '../access.js'
 import { createSigner } from '../signer.js'
 import { createCarStore } from '../buckets/car-store.js'
 import { createStoreTable } from '../tables/store.js'
@@ -39,9 +39,8 @@ async function ucanInvocationRouter (request) {
     }
   }
 
-  const id = await getServiceDid()
-  const server = await createUcantoServer(id, {
-    id,
+  const serviceSigner = await getServiceDid()
+  const server = await createUcantoServer(serviceSigner, {
     storeTable: createStoreTable(AWS_REGION, storeTableName, {
       endpoint: dbEndpoint
     }),
@@ -53,7 +52,7 @@ async function ucanInvocationRouter (request) {
       sessionToken: AWS_SESSION_TOKEN,
       bucket: storeBucketName,
     }),
-    access: createAccess(id, DID.parse(accessServiceDID), new URL(accessServiceURL))
+    access: createAccessClient(serviceSigner, DID.parse(accessServiceDID), new URL(accessServiceURL))
   })
   const response = await server.request({
     // @ts-expect-error - type is Record<string, string|string[]|undefined>

--- a/api/functions/ucan-invocation-router.js
+++ b/api/functions/ucan-invocation-router.js
@@ -71,12 +71,12 @@ async function ucanInvocationRouter (request) {
 export const handler = ucanInvocationRouter
 
 /**
- * @param {import('@ipld/dag-ucan').Principal} id
+ * @param {import('@ipld/dag-ucan').Principal} servicePrincipal
  * @param {import('../service/types').UcantoServerContext} context
  */
-export async function createUcantoServer (id, context) {
+export async function createUcantoServer (servicePrincipal, context) {
   const server = Server.create({
-    id,
+    id: servicePrincipal,
     encoder: CBOR,
     decoder: CAR,
     service: createServiceRouter(context),

--- a/api/package.json
+++ b/api/package.json
@@ -13,6 +13,7 @@
     "@ucanto/principal": "^3.0.1",
     "@ucanto/server": "^3.0.4",
     "@ucanto/transport": "^3.0.2",
+    "@web-std/fetch": "^4.1.0",
     "@web3-storage/access": "^5.0.2",
     "@web3-storage/sigv4": "^1.0.2",
     "multiformats": "^10.0.2"

--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "test": "ava --verbose --timeout=60s **/*.test.js"
+    "test": "ava --verbose --timeout=60s --serial **/*.test.js"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.211.0",

--- a/api/service/types.ts
+++ b/api/service/types.ts
@@ -1,8 +1,7 @@
-import type { Link, Principal, Invocation } from '@ucanto/interface'
+import type { Link, Invocation } from '@ucanto/interface'
 import type { API, MalformedCapability } from '@ucanto/server'
 
 export interface StoreServiceContext {
-  servicePrincipal: Principal
   storeTable: StoreTable,
   signer: Signer
   carStoreBucket: CarStoreBucket,

--- a/api/service/types.ts
+++ b/api/service/types.ts
@@ -1,10 +1,12 @@
-import type { Link } from '@ucanto/interface'
+import type { Link, Principal, Invocation } from '@ucanto/interface'
 import type { API, MalformedCapability } from '@ucanto/server'
 
 export interface StoreServiceContext {
+  id: Principal
   storeTable: StoreTable,
   signer: Signer
   carStoreBucket: CarStoreBucket,
+  access: AccessClient
 }
 
 export interface UcantoServerContext extends StoreServiceContext {}
@@ -67,4 +69,12 @@ export interface ListResponse<R> {
   cursorID?: string,
   pageSize: number,
   results: R[]
+}
+
+export interface AccessClient {
+  /**
+   * Determines if the issuer of the invocation has received a delegation
+   * allowing them to issue the passed invocation.
+   */
+  verifyInvocation: (invocation: Invocation) => Promise<boolean>
 }

--- a/api/service/types.ts
+++ b/api/service/types.ts
@@ -10,7 +10,6 @@ export interface StoreServiceContext {
 
 export interface UploadServiceContext {
   uploadTable: UploadTable
-  access: AccessClient
 }
 
 export interface UcantoServerContext extends StoreServiceContext, UploadServiceContext {}

--- a/api/tables/store.js
+++ b/api/tables/store.js
@@ -30,17 +30,17 @@ export function createStoreTable (region, tableName, options = {}) {
      * @param {string} payloadCID
      */
     exists: async (uploaderDID, payloadCID) => {
-      const params = {
+      const cmd = new GetItemCommand({
         TableName: tableName,
         Key: marshall({
           uploaderDID,
           payloadCID,
         }),
         AttributesToGet: ['uploaderDID'],
-      }
+      })
   
       try {
-        const response = await dynamoDb.send(new GetItemCommand(params))
+        const response = await dynamoDb.send(cmd)
         return response?.Item !== undefined
       } catch {
         return false
@@ -62,12 +62,12 @@ export function createStoreTable (region, tableName, options = {}) {
         uploadedAt: new Date().toISOString(),
       }
   
-      const params = {
+      const cmd = new PutItemCommand({
         TableName: tableName,
         Item: marshall(item),
-      }
+      })
   
-      await dynamoDb.send(new PutItemCommand(params))
+      await dynamoDb.send(cmd)
   
       return item
     },

--- a/api/test/helpers/ucanto.js
+++ b/api/test/helpers/ucanto.js
@@ -9,12 +9,13 @@ import { createUploadTable } from '../../tables/upload.js'
 import { createSigner } from '../../signer.js'
 
 import { getSigningOptions } from '../utils.js'
+import { createAccessClient } from '../../access.js'
 
 /**
- * @param {any} ctx
+ * @param {import('./context.js').UcantoServerContext} ctx
  */
 export function createTestingUcantoServer(ctx) {
- return createUcantoServer({
+ return createUcantoServer(ctx.serviceDid, {
    storeTable: createStoreTable(ctx.region, ctx.tableName, {
      endpoint: ctx.dbEndpoint
    }),
@@ -22,7 +23,8 @@ export function createTestingUcantoServer(ctx) {
      endpoint: ctx.dbEndpoint
    }),
    carStoreBucket: createCarStore(ctx.region, ctx.bucketName, { ...ctx.s3ClientOpts }),
-   signer: createSigner(getSigningOptions(ctx))
+   signer: createSigner(getSigningOptions(ctx)),
+   access: createAccessClient(ctx.serviceDid, ctx.access.servicePrincipal, ctx.access.serviceURL)
  })
 }
 

--- a/api/test/service/store.test.js
+++ b/api/test/service/store.test.js
@@ -4,6 +4,7 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { PutObjectCommand } from '@aws-sdk/client-s3'
 import * as Signer from '@ucanto/principal/ed25519'
 import { CAR } from '@ucanto/transport'
+import * as Server from '@ucanto/server'
 import * as StoreCapabilities from '@web3-storage/access/capabilities/store'
 import { base64pad } from 'multiformats/bases/base64'
 import getServiceDid from '../../authority.js'
@@ -168,42 +169,35 @@ test('store/add allowed if invocation passes access verification', async (t) => 
   t.is(service.account.info.callCount, 1)
 })
 
-// test('store/add disallowed if invocation fails access verification', async (t) => {
-//   const uploadService = t.context.serviceDid
-//   const alice = await Signer.generate()
-//   const { proof, spaceDid } = await createSpace(alice)
-//   const connection = await getClientConnection(uploadService, t.context)
+test('store/add disallowed if invocation fails access verification', async (t) => {
+  t.context.access.setServiceImpl({
+    account: { info: () => { return new Server.Failure('not found') } }
+  })
 
-//   const data = new Uint8Array([11, 22, 34, 44, 55])
-//   const link = await CAR.codec.link(data)
+  const uploadService = t.context.serviceDid
+  const alice = await Signer.generate()
+  const { proof, spaceDid } = await createSpace(alice)
+  const connection = await getClientConnection(uploadService, t.context)
 
-//   // invoke a store/add with proof
-//   const storeAdd = await StoreCapabilities.add.invoke({
-//     issuer: alice,
-//     audience: uploadService,
-//     with: spaceDid,
-//     nb: { link, size: data.byteLength },
-//     proofs: [proof]
-//     // @ts-expect-error ʅʕ•ᴥ•ʔʃ
-//   }).execute(connection)
+  const data = new Uint8Array([11, 22, 34, 44, 55])
+  const link = await CAR.codec.link(data)
 
-//   t.not(storeAdd.error, true, storeAdd.message)
-//   t.is(storeAdd.status, 'upload')
-//   t.is(storeAdd.with, spaceDid)
-//   t.deepEqual(storeAdd.link, link)
-//   t.is(new URL(storeAdd.url).pathname, `/${link}/${link}.car`)
-//   t.is(storeAdd.headers['x-amz-checksum-sha256'], base64pad.baseEncode(link.multihash.digest))
+  // invoke a store/add with proof
+  const storeAdd = await StoreCapabilities.add.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: spaceDid,
+    nb: { link, size: data.byteLength },
+    proofs: [proof]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
 
-//   const item = await getItemFromStoreTable(t.context.dynamoClient, spaceDid, link)
-//   t.truthy(item)
-//   t.is(typeof item?.uploadedAt, 'string')
-//   t.is(typeof item?.proof, 'string')
-//   t.is(typeof item?.uploaderDID, 'string')
-//   // TODO: this looks suspicious... why is uploaderDID not the issuer / alice who invoked the upload
-//   t.is(item?.uploaderDID, spaceDid)
-//   t.is(typeof item?.size, 'number')
-//   t.is(item?.size, data.byteLength)
-// })
+  t.is(storeAdd.error, true)
+
+  const { service } = t.context.access.server
+  t.true(service.account.info.called)
+  t.is(service.account.info.callCount, 1)
+})
 
 test('store/remove does not fail for non existent link', async (t) => {
   const uploadService = t.context.serviceDid

--- a/api/test/service/store.test.js
+++ b/api/test/service/store.test.js
@@ -2,18 +2,16 @@ import { testStore as test } from '../helpers/context.js'
 import { CreateTableCommand, GetItemCommand } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { PutObjectCommand } from '@aws-sdk/client-s3'
-
-import { parse } from '@ipld/dag-ucan/did'
+import * as Signer from '@ucanto/principal/ed25519'
 import { CAR, CBOR } from '@ucanto/transport'
-import { DID } from '@ucanto/core'
-
+import * as UcantoClient from '@ucanto/client'
+import * as StoreCapabilities from '@web3-storage/access/capabilities/store'
 import getServiceDid from '../../authority.js'
 import { createUcantoServer } from '../../functions/ucan-invocation-router.js'
 import { createCarStore } from '../../buckets/car-store.js'
 import { createStoreTable } from '../../tables/store.js'
 import { createSigner } from '../../signer.js'
-
-import { alice } from '../fixtures.js'
+import { base64pad } from 'multiformats/bases/base64'
 import { createS3, createBucket, createDynamodDb, getSigningOptions } from '../utils.js'
 
 test.beforeEach(async t => {
@@ -42,51 +40,76 @@ test.beforeEach(async t => {
 })
 
 test('store add returns signed url for uploading', async (t) => {
-  const server = await createStoreUcantoServer(t.context)
-  const account = alice.did()
+  const uploadService = t.context.serviceDid
+  const alice = await Signer.generate()
+  const space = await Signer.generate()
   const data = new Uint8Array([11, 22, 34, 44, 55])
   const link = await CAR.codec.link(data)
 
-  const request = await CAR.encode([
-    {
-      issuer: alice,
-      audience: parse(t.context.serviceDid.did()),
-      capabilities: [{
-        can: 'store/add',
-        with: account,
-        nb: { link, size: data.byteLength },
-      }],
-      proofs: [],
-    }
-  ])
+  const connection = UcantoClient.connect({
+    id: uploadService,
+    encoder: CAR,
+    decoder: CBOR,
+    channel: await createStoreUcantoServer(t.context),
+  })
 
-  const storeAddResponse = await server.request(request)
-  /** @type {import('../../service/types').StoreAddSuccessResult[]} */
-  // @ts-expect-error
-  const storeAdd = await CBOR.decode(storeAddResponse)
-  t.is(storeAdd.length, 1)
-  t.is(storeAdd[0].status, 'upload')
-  t.is(storeAdd[0].with, account)
-  t.deepEqual(storeAdd[0].link, link)
-  t.truthy(storeAdd[0].url)
+  // alice may do anything to this space
+  const proof = await UcantoClient.delegate({
+    issuer: space,
+    audience: alice,
+    capabilities: [{ can: '*', with: space.did() }]
+  })
 
-  const item = await getItemFromStoreTable(t.context.dynamoClient, alice, link)
+  // invoke a store/add with proof
+  const storeAdd = await StoreCapabilities.add.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: space.did(),
+    nb: { link, size: data.byteLength },
+    proofs: [proof]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+
+  t.not(storeAdd.error, true, storeAdd.message)
+  t.is(storeAdd.status, 'upload')
+  t.is(storeAdd.with, space.did())
+  t.deepEqual(storeAdd.link, link)
+  t.is(new URL(storeAdd.url).pathname, `/${link}/${link}.car`)
+  t.is(storeAdd.headers['x-amz-checksum-sha256'], base64pad.baseEncode(link.multihash.digest))
+
+  const item = await getItemFromStoreTable(t.context.dynamoClient, space, link)
   t.truthy(item)
   t.is(typeof item?.uploadedAt, 'string')
   t.is(typeof item?.proof, 'string')
   t.is(typeof item?.uploaderDID, 'string')
-  t.is(item?.uploaderDID, account)
-  t.truthy(DID.parse(item?.uploaderDID))
+  // TODO: this looks suspicious... why is uploaderDID not the issuer / alice who invoked the upload
+  t.is(item?.uploaderDID, space.did())
   t.is(typeof item?.size, 'number')
   t.is(item?.size, data.byteLength)
 })
 
 test('store add returns done if already uploaded', async (t) => {
-  const server = await createStoreUcantoServer(t.context)
-  const account = alice.did()
+  const uploadService = t.context.serviceDid
+  const alice = await Signer.generate()
+  const space = await Signer.generate()
   const data = new Uint8Array([11, 22, 34, 44, 55])
   const link = await CAR.codec.link(data)
 
+  const connection = UcantoClient.connect({
+    id: uploadService,
+    encoder: CAR,
+    decoder: CBOR,
+    channel: await createStoreUcantoServer(t.context),
+  })
+
+  // alice may do anything to this space
+  const proof = await UcantoClient.delegate({
+    issuer: space,
+    audience: alice,
+    capabilities: [{ can: '*', with: space.did() }]
+  })
+
+  // simulate an already stored CAR
   await t.context.s3Client.send(
     new PutObjectCommand({
       Bucket: t.context.bucketName,
@@ -95,190 +118,213 @@ test('store add returns done if already uploaded', async (t) => {
     })
   )
 
-  const request = await CAR.encode([
-    {
-      issuer: alice,
-      audience: parse(t.context.serviceDid.did()),
-      capabilities: [{
-        can: 'store/add',
-        with: account,
-        nb: { link, size: data.byteLength },
-      }],
-      proofs: [],
-    }
-  ])
+  const storeAdd = await StoreCapabilities.add.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: space.did(),
+    nb: { link, size: data.byteLength },
+    proofs: [proof]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
 
-  const storeAddResponse = await server.request(request)
-  /** @type {import('../../service/types').StoreAddSuccessResult[]} */
-  // @ts-expect-error
-  const storeAdd = await CBOR.decode(storeAddResponse)
-
-  t.is(storeAdd.length, 1)
-  t.is(storeAdd[0].status, 'done')
-  t.is(storeAdd[0].with, account)
-  t.deepEqual(storeAdd[0].link, link)
-  t.falsy(storeAdd[0].url)
+  t.is(storeAdd.status, 'done')
+  t.is(storeAdd.with, space.did())
+  t.deepEqual(storeAdd.link, link)
+  t.falsy(storeAdd.url)
 
   // Even if done (CAR already exists in bucket), mapped to user if non existing
-  const item = await getItemFromStoreTable(t.context.dynamoClient, alice, link)
+  const item = await getItemFromStoreTable(t.context.dynamoClient, space, link)
   t.is(typeof item?.uploadedAt, 'string')
   t.is(typeof item?.proof, 'string')
   t.is(typeof item?.uploaderDID, 'string')
-  t.is(item?.uploaderDID, account)
-  t.truthy(DID.parse(item?.uploaderDID))
+  t.is(item?.uploaderDID, space.did())
   t.is(typeof item?.size, 'number')
   t.is(item?.size, data.byteLength)
 })
 
 test('store remove does not fail for non existent link', async (t) => {
-  const server = await createStoreUcantoServer(t.context)
-  const account = alice.did()
+  const uploadService = t.context.serviceDid
+  const alice = await Signer.generate()
+  const space = await Signer.generate()
   const data = new Uint8Array([11, 22, 34, 44, 55])
   const link = await CAR.codec.link(data)
 
-  const request = await CAR.encode([
-    {
-      issuer: alice,
-      audience: parse(t.context.serviceDid.did()),
-      capabilities: [{
-        can: 'store/remove',
-        with: account,
-        nb: { link },
-      }],
-      proofs: [],
-    }
-  ])
+  const connection = UcantoClient.connect({
+    id: uploadService,
+    encoder: CAR,
+    decoder: CBOR,
+    channel: await createStoreUcantoServer(t.context),
+  })
 
-  const storeRemoveResponse = await server.request(request)
-  const storeRemove = await CBOR.decode(storeRemoveResponse)
-  t.is(storeRemove.length, 1)
+  // alice may do anything to this space
+  const proof = await UcantoClient.delegate({
+    issuer: space,
+    audience: alice,
+    capabilities: [{ can: '*', with: space.did() }]
+  })
+
+  const storeRemove = await StoreCapabilities.remove.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: space.did(),
+    nb: { link },
+    proofs: [proof]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+
+  // expect no response for a remove
+  t.falsy(storeRemove)
+
+  const storeRemove2 = await StoreCapabilities.remove.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: space.did(),
+    nb: { link },
+    proofs: [proof]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+
+  // expect no response for a remove
+  t.falsy(storeRemove2)
 })
 
 test('store remove invocation removes car bound to issuer from store table', async (t) => {
-  const server = await createStoreUcantoServer(t.context)
-  const account = alice.did()
-  const link = await CAR.codec.link(
-    new Uint8Array([11, 22, 34, 44, 55])
-  )
+  const uploadService = t.context.serviceDid
+  const alice = await Signer.generate()
+  const space = await Signer.generate()
+  const data = new Uint8Array([11, 22, 34, 44, 55])
+  const link = await CAR.codec.link(data)
+
+  const connection = UcantoClient.connect({
+    id: uploadService,
+    encoder: CAR,
+    decoder: CBOR,
+    channel: await createStoreUcantoServer(t.context),
+  })
+
+  // alice may do anything to this space
+  const proof = await UcantoClient.delegate({
+    issuer: space,
+    audience: alice,
+    capabilities: [{ can: '*', with: space.did() }]
+  })
 
   // Validate Store Table content does not exist before add
-  const dynamoItemBeforeAdd = await getItemFromStoreTable(t.context.dynamoClient, alice, link)
+  const dynamoItemBeforeAdd = await getItemFromStoreTable(t.context.dynamoClient, space, link)
   t.falsy(dynamoItemBeforeAdd)
 
-  const addRequest = await CAR.encode([
-    {
-      issuer: alice,
-      audience: parse(t.context.serviceDid.did()),
-      capabilities: [{
-        can: 'store/add',
-        with: account,
-        nb: { link, size: 5 },
-      }],
-      proofs: [],
-    }
-  ])
-  await server.request(addRequest)
+  const storeAdd = await StoreCapabilities.add.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: space.did(),
+    nb: { link, size: data.byteLength },
+    proofs: [proof]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+
+  t.is(storeAdd.status, 'upload')
 
   // Validate Store Table content exists after add
-  const dynamoItemAfterAdd = await getItemFromStoreTable(t.context.dynamoClient, alice, link)
+  const dynamoItemAfterAdd = await getItemFromStoreTable(t.context.dynamoClient, space, link)
   t.truthy(dynamoItemAfterAdd)
 
-  const removeRequest = await CAR.encode([
-    {
-      issuer: alice,
-      audience: parse(t.context.serviceDid.did()),
-      capabilities: [{
-        can: 'store/remove',
-        with: account,
-        nb: { link },
-      }],
-      proofs: [],
-    }
-  ])
-  const storeRemoveResponse = await server.request(removeRequest)
-  const storeRemove = await CBOR.decode(storeRemoveResponse)
-  t.is(storeRemove.length, 1)
+  const storeRemove = await StoreCapabilities.remove.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: space.did(),
+    nb: { link },
+    proofs: [proof]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+
+  t.falsy(storeRemove)
 
   // Validate Store Table content does not exist after remove
-  const dynamoItemAfterRemove = await getItemFromStoreTable(t.context.dynamoClient, alice, link)
+  const dynamoItemAfterRemove = await getItemFromStoreTable(t.context.dynamoClient, space, link)
   t.falsy(dynamoItemAfterRemove)
 })
 
 test('store list does not fail for empty list', async (t) => {
-  const server = await createStoreUcantoServer(t.context)
-  const account = alice.did()
+  const uploadService = t.context.serviceDid
+  const alice = await Signer.generate()
+  const space = await Signer.generate()
 
-  const request = await CAR.encode([
-    {
-      issuer: alice,
-      audience: parse(t.context.serviceDid.did()),
-      capabilities: [{
-        can: 'store/list',
-        with: account,
-      }],
-      proofs: [],
-    }
-  ])
+  const connection = UcantoClient.connect({
+    id: uploadService,
+    encoder: CAR,
+    decoder: CBOR,
+    channel: await createStoreUcantoServer(t.context),
+  })
 
-  const storeListResponse = await server.request(request)
-  /** @type {import('../../service/types').ListResponse<any>[]} */
-  // @ts-expect-error
-  const storeList = await CBOR.decode(storeListResponse)
-  t.is(storeList.length, 1)
-  t.is(storeList[0].results.length, 0)
-  t.is(storeList[0].pageSize, 0)
+  // alice may do anything to this space
+  const proof = await UcantoClient.delegate({
+    issuer: space,
+    audience: alice,
+    capabilities: [{ can: '*', with: space.did() }]
+  })
+  
+  const storeList = await StoreCapabilities.list.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: space.did(),
+    proofs: [ proof ]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+
+  t.like(storeList, { results: [], pageSize: 0 })
 })
 
 test('store list returns items previously stored by the user', async (t) => {
-  const server = await createStoreUcantoServer(t.context)
-  const account = alice.did()
+  const uploadService = t.context.serviceDid
+  const alice = await Signer.generate()
+  const space = await Signer.generate()
 
-  // Request to store a few links
-  const links = await Promise.all([
-    new Uint8Array([11, 22, 34, 44, 55]),
-    new Uint8Array([22, 34, 44, 55, 66])
-  ].map(async (data) => {
-    const link = await CAR.codec.link(data)
-    const request = await CAR.encode([
-      {
-        issuer: alice,
-        audience: parse(t.context.serviceDid.did()),
-        capabilities: [{
-          can: 'store/add',
-          with: account,
-          nb: { link, size: 5 },
-        }],
-        proofs: [],
-      }
-    ])
-    await server.request(request)
+  const connection = UcantoClient.connect({
+    id: uploadService,
+    encoder: CAR,
+    decoder: CBOR,
+    channel: await createStoreUcantoServer(t.context),
+  })
 
-    return link
-  }))
+  // alice may do anything to this space
+  const proof = await UcantoClient.delegate({
+    issuer: space,
+    audience: alice,
+    capabilities: [{ can: '*', with: space.did() }]
+  })
 
-  const request = await CAR.encode([
-    {
+  const data = [ new Uint8Array([11, 22, 34, 44, 55]), new Uint8Array([22, 34, 44, 55, 66]) ]
+  const links = []
+  for (const datum of data) {
+    const storeAdd = await StoreCapabilities.add.invoke({
       issuer: alice,
-      audience: parse(t.context.serviceDid.did()),
-      capabilities: [{
-        can: 'store/list',
-        with: account,
-      }],
-      proofs: [],
-    }
-  ])
+      audience: uploadService,
+      with: space.did(),
+      nb: { link: await CAR.codec.link(datum) , size: datum.byteLength },
+      proofs: [proof]
+      // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+    }).execute(connection)
+    t.not(storeAdd.error, true, storeAdd.message)
+    t.is(storeAdd.status, 'upload')
+    links.push(storeAdd.link)
+  }
 
-  const storeListResponse = await server.request(request)
-  /** @type {import('../../service/types').ListResponse<import('../../service/types').StoreListResult>[]} */
-  // @ts-expect-error
-  const storeList = await CBOR.decode(storeListResponse)
-  t.is(storeList.length, 1)
-  t.is(storeList[0].results.length, 2)
-  t.is(storeList[0].pageSize, 2)
+  const storeList = await StoreCapabilities.list.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: space.did(),
+    proofs: [ proof ]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
 
-  // Has stored links
-  for (const link of links) {
-    t.truthy(storeList[0].results.find(i => i.payloadCID === link.toString()))
+  t.is(storeList.pageSize, links.length)
+
+  // list order last-in-first-out
+  links.reverse()
+  let i = 0
+  for (const entry of storeList.results) {
+    t.like(entry, { payloadCID: links[i].toString(), size: 5, origin: '' })
+    i++
   }
 })
 

--- a/api/test/service/upload.test.js
+++ b/api/test/service/upload.test.js
@@ -7,7 +7,7 @@ import * as UploadCapabilities from '@web3-storage/access/capabilities/upload'
 import getServiceDid from '../../authority.js'
 import { BATCH_MAX_SAFE_LIMIT } from '../../tables/upload.js'
 
-import { createDynamodDb } from '../utils.js'
+import { createAccessServer, createDynamodDb } from '../utils.js'
 import { randomCAR } from '../helpers/random.js'
 import { getClientConnection, createSpace } from '../helpers/ucanto.js'
 
@@ -22,11 +22,17 @@ test.beforeEach(async t => {
   } = await createDynamodDb({ port: 8000, region })
   await createDynamoUploadTable(dynamo)
 
+  // Access
+  const access = await createAccessServer()
+
   t.context.dbEndpoint = dbEndpoint
   t.context.dynamoClient = dynamo
   t.context.tableName = tableName
   t.context.region = region
   t.context.serviceDid = await getServiceDid()
+  t.context.access = access
+  t.context.accessServiceDID = access.servicePrincipal.did()
+  t.context.accessServiceURL = access.serviceURL.toString()
 })
 
 test('upload/add inserts into DB mapping between data CID and car CIDs', async (t) => {

--- a/api/test/utils.js
+++ b/api/test/utils.js
@@ -143,9 +143,10 @@ export async function createAccessServer () {
   return { servicePrincipal, serviceURL, setServiceImpl, server, httpServer }
 }
 
+const notImplemented = () => { throw new Server.Failure('not implemented') }
+
 /** @param {PartialAccessService} [impl] */
 function mockAccessService (impl = {}) {
-  const notImplemented = () => { throw new Server.Failure('not implemented') }
   return {
     voucher: {
       claim: withCallCount(impl.voucher?.claim ?? notImplemented),

--- a/api/test/utils.js
+++ b/api/test/utils.js
@@ -14,8 +14,8 @@ import * as HTTP from 'http'
  * }>} PartialAccessService
  * @typedef {ReturnType<mockAccessService>} MockedAccessService
  * @typedef {{
- *   serviceDID: string
- *   serviceURL: string
+ *   servicePrincipal: import('@ucanto/interface').Principal
+ *   serviceURL: URL
  *   setServiceImpl: (impl: PartialAccessService) => void
  *   server: import('@ucanto/server').ServerView<MockedAccessService>
  *   httpServer: HTTP.Server
@@ -98,7 +98,7 @@ export function getSigningOptions(ctx) {
 }
 
 /** @returns {Promise<MockAccess>} */
-export async function createAccess () {
+export async function createAccessServer () {
   const signer = await Signer.generate()
   const server = Server.create({
     id: signer,
@@ -128,19 +128,19 @@ export async function createAccess () {
     }
   })
 
-  const serviceDID = signer.did()
+  const servicePrincipal = signer
   const serviceURL = await new Promise(resolve => {
     httpServer.listen(() => {
       // @ts-expect-error
-      const { address, port } = httpServer.address()
-      const serviceURL = `http://${address}:${port}`
+      const { port } = httpServer.address()
+      const serviceURL = new URL(`http://127.0.0.1:${port}`)
       resolve(serviceURL)
     })
   })
   /** @param {PartialAccessService} impl */
   const setServiceImpl = impl => Object.assign(server.service, mockAccessService(impl))
 
-  return { serviceDID, serviceURL, setServiceImpl, server, httpServer }
+  return { servicePrincipal, serviceURL, setServiceImpl, server, httpServer }
 }
 
 /** @param {PartialAccessService} [impl] */

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@ucanto/principal": "^3.0.1",
         "@ucanto/server": "^3.0.4",
         "@ucanto/transport": "^3.0.2",
+        "@web-std/fetch": "^4.1.0",
         "@web3-storage/access": "^5.0.2",
         "@web3-storage/sigv4": "^1.0.2",
         "multiformats": "^10.0.2"
@@ -20959,6 +20960,7 @@
         "@ucanto/server": "^3.0.4",
         "@ucanto/transport": "^3.0.2",
         "@web-std/blob": "3.0.4",
+        "@web-std/fetch": "*",
         "@web3-storage/access": "^5.0.2",
         "@web3-storage/sigv4": "^1.0.2",
         "ava": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,22 @@
       "project": "./tsconfig.json"
     },
     "rules": {
+      "unicorn/prefer-number-properties": "off",
+      "unicorn/no-null": "off",
+      "unicorn/no-array-for-each": "off",
+      "unicorn/no-await-expression-member": "off",
+      "unicorn/prefer-set-has": "off",
+      "unicorn/prefer-export-from": "off",
+      "unicorn/catch-error-name": "off",
+      "unicorn/explicit-length-check": "off",
+      "unicorn/prefer-type-error": "off",
+      "eqeqeq": "off",
+      "no-void": "off",
       "no-console": "off",
-      "no-warning-comments": "off"
+      "no-continue": "off",
+      "no-warning-comments": "off",
+      "jsdoc/check-indentation": "off",
+      "jsdoc/require-hyphen-before-param-description": "off"
     }
   },
   "workspaces": [


### PR DESCRIPTION
This PR adds a request to w3access when a `store/add` invocation is handled.

The request to w3access ensures that the target space has been verified by a user via email.