### PR TITLE
fix: update deps

### DIFF
--- a/api/service/store/add.js
+++ b/api/service/store/add.js
@@ -13,8 +13,6 @@ export function storeAddProvider(context) {
   return Server.provide(
     Store.add,
     async ({ capability, invocation }) => {
-      /** @type {{ link: Link, origin: Link, size: number }} */
-      // @ts-ignore need to add types from capabilities here
       const { link, origin, size } = capability.nb
       const proof = invocation.cid
 
@@ -22,6 +20,11 @@ export function storeAddProvider(context) {
         return new Server.MalformedCapability(
           invocation.capabilities[0],
           new Server.Failure('Provided capability has no link')
+        )
+      } else if (!size) {
+        return new Server.MalformedCapability(
+          invocation.capabilities[0],
+          new Server.Failure('Provided capability has no size')
         )
       }
 
@@ -43,7 +46,7 @@ export function storeAddProvider(context) {
           uploaderDID: account,
           link: link.toString(),
           proof: proof.toString(),
-          origin: origin && origin.toString(),
+          origin: origin?.toString(),
           size
         })
       }

--- a/api/service/types.ts
+++ b/api/service/types.ts
@@ -25,7 +25,7 @@ export interface Signer {
 export interface StoreItemInput {
   uploaderDID: string,
   link: string,
-  origin: string,
+  origin?: string,
   size: number,
   proof: string,
 }

--- a/api/test/service/store.test.js
+++ b/api/test/service/store.test.js
@@ -54,7 +54,7 @@ test('store add returns signed url for uploading', async (t) => {
       capabilities: [{
         can: 'store/add',
         with: account,
-        nb: { link },
+        nb: { link, size: 5 },
       }],
       proofs: [],
     }
@@ -98,7 +98,7 @@ test('store add returns done if already uploaded', async (t) => {
       capabilities: [{
         can: 'store/add',
         with: account,
-        nb: { link },
+        nb: { link, size: 5 },
       }],
       proofs: [],
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,22 +11,22 @@
         "api"
       ],
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.208.0",
-        "@aws-sdk/client-s3": "^3.209.0",
-        "@aws-sdk/util-dynamodb": "^3.208.0",
-        "@serverless-stack/node": "^1.17.1",
+        "@aws-sdk/client-dynamodb": "^3.211.0",
+        "@aws-sdk/client-s3": "^3.211.0",
+        "@aws-sdk/util-dynamodb": "^3.211.0",
+        "@serverless-stack/node": "^1.18.0",
         "@ucanto/interface": "^3.0.1",
-        "@ucanto/principal": "^3.0.0",
-        "@ucanto/server": "^3.0.1",
-        "@ucanto/transport": "^3.0.1",
-        "@web3-storage/access": "^4.0.2",
+        "@ucanto/principal": "^3.0.1",
+        "@ucanto/server": "^3.0.4",
+        "@ucanto/transport": "^3.0.2",
+        "@web3-storage/access": "^5.0.1",
         "@web3-storage/sigv4": "^1.0.2",
         "multiformats": "^10.0.2"
       },
       "devDependencies": {
         "@ipld/dag-ucan": "^2.0.1",
-        "@serverless-stack/cli": "^1.17.1",
-        "@serverless-stack/resources": "^1.17.1",
+        "@serverless-stack/cli": "^1.18.0",
+        "@serverless-stack/resources": "^1.18.0",
         "@tsconfig/node16": "^1.0.3",
         "@types/aws-lambda": "^8.10.108",
         "ava": "^4.3.3",
@@ -35,7 +35,7 @@
         "lint-staged": "^13.0.3",
         "nanoid": "^4.0.0",
         "testcontainers": "^8.13.0",
-        "typescript": "^4.8.4"
+        "typescript": "^4.9.3"
       }
     },
     "api": {
@@ -221,29 +221,21 @@
         "tslib": "^1.11.1"
       }
     },
-    "node_modules/@aws-crypto/util/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-crypto/util/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.40.0.tgz",
-      "integrity": "sha512-S7LzLvNuwuf0q7r4q7zqGzxd/W2xYsn8cpZ90MMb3ObolhbkLySrikUJujmXae8k+2/KFCOr+FVC0YLrATSUgQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
+      "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
       "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/chunked-blob-reader": {
@@ -264,16 +256,16 @@
       }
     },
     "node_modules/@aws-sdk/client-codebuild": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-codebuild/-/client-codebuild-3.208.0.tgz",
-      "integrity": "sha512-chw3bztFWvo40zN+QYG8OMMZ8u2esdtLHAohqIm8BRoyL3+KDlAe2BL/Jeu/RTJ9ZNdu47HfeSfwgzKqWFCDaQ==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-codebuild/-/client-codebuild-3.211.0.tgz",
+      "integrity": "sha512-cPmfX5TPMbPerGrOmN0NUewxdteyeVLmTIMnTkl20/LWhrg1sFS86/11xNiwYNxcpr6qQgnDY7KtdYVqnYsGiA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.208.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-node": "3.208.0",
+        "@aws-sdk/client-sts": "3.211.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.211.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
@@ -282,813 +274,71 @@
         "@aws-sdk/middleware-host-header": "3.208.0",
         "@aws-sdk/middleware-logger": "3.208.0",
         "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
         "@aws-sdk/middleware-serde": "3.208.0",
         "@aws-sdk/middleware-signing": "3.208.0",
         "@aws-sdk/middleware-stack": "3.208.0",
         "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/node-http-handler": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/url-parser": "3.208.0",
         "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
-      "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/client-sso": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.208.0.tgz",
-      "integrity": "sha512-3e6kEFtuxqZVv1cLGbXFAytTPzR1GpctKITEtJR0MFy3pzj8ttbybrHe0F8z2AqAtDhna1i3u1WVZa+LK3gE9Q==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/client-sts": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.208.0.tgz",
-      "integrity": "sha512-xmPxI/vW0YVm2YhmIfdTQYY8b8dvzP0ordgooDlzAZVj5KnpZLVzQUxin5EqVcZYFJp6qEkVwmFK03QLy9fYOw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-node": "3.208.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
-        "@aws-sdk/middleware-sdk-sts": "3.208.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.208.0.tgz",
-      "integrity": "sha512-eLwI7rjk3AJj/S8PqRcUi9iBD+cTm1Nzu1CmYyeiwU6YbJLe5/2CrhW1wjkOGleE+aD967U1TWiB18tsx6fj+w==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz",
-      "integrity": "sha512-FB+KUSpZc03wVTXxGnMmgtaP0sJOv0D7oyogHb7wcf5b7RjjwqoaeUcJHTdKRZaW6e1foLk3/L9uebxiWefDbQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.208.0.tgz",
-      "integrity": "sha512-z4Bk42FQefBzS1SZ6/4gsAFE7tQhEoDmSUrFVSDu/9WwvGpFMnFfHLTBhivlcAHjc/eQ/hiWYLnQ8vahqhHl8w==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.208.0.tgz",
-      "integrity": "sha512-AhsUj4046wMnxrPunNVEuddOIb//KsaicRqucw1Pb/UqszDRO4hYWkw7pL10MPIqjHBwuXYZ3vjDZrIhIWMn7A==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.208.0",
-        "@aws-sdk/credential-provider-sso": "3.208.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.208.0.tgz",
-      "integrity": "sha512-KYoxlpDzvhw6v0ae0TgIGPP52HJUHQGI3yImhAZZTz0Nh5B0zd2stip+p36sCYRW6V+TJ5mo5minwqDmYe8oXg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.208.0",
-        "@aws-sdk/credential-provider-ini": "3.208.0",
-        "@aws-sdk/credential-provider-process": "3.208.0",
-        "@aws-sdk/credential-provider-sso": "3.208.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.208.0.tgz",
-      "integrity": "sha512-ExvFSJB/pVV+/BXIvFR9dgoGxWWnF6uqIw1hfpWCh28UDwsOQdbfUKblMovUfPDBUw67Laqy3mtiY37Jyo/EUQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.208.0.tgz",
-      "integrity": "sha512-GVUBmSG8eO4oXy5XpslAgVUBimEVBYmyCdwrwED79ey/7NWfkIVt46VZQapWyAJsarKW+VFpx7BYnam9YBR6hA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.208.0.tgz",
-      "integrity": "sha512-7wtrdEr8uvDr5t0stimrXGsW4G+TQyluZ9OucCCY0HXgNihmnk1BIu+COuOSxRtFXHwCh4rIPaVE1ABG2Mq24g==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
-      "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/querystring-builder": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/hash-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz",
-      "integrity": "sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz",
-      "integrity": "sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz",
-      "integrity": "sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz",
-      "integrity": "sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz",
-      "integrity": "sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.208.0.tgz",
-      "integrity": "sha512-JAcN2e3PKWGcNX7run/jP6xJ7w2m15a2CpVrfMtka9p/I/3qnqB86jGUs/3Iv04FEqgXq7KTHbFBg8CndsaHEw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/service-error-classification": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.208.0.tgz",
-      "integrity": "sha512-lFVodZHYLF7puXgNZ1m5ycKbyCPp79nqI+pkRXl066ZtZWzCW8+JKCaLjF3jfXlnvg6foPDJdxUvt0VU5EddGg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
-      "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.208.0.tgz",
-      "integrity": "sha512-cMSWhg8xOrxZw04EYKEQQQ7RT+03rigS4KS3Uy6x/M+jFyoM+sRiY/7376sJCwlpvKH2xJIVpwPbKk/uz4j4DA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz",
-      "integrity": "sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz",
-      "integrity": "sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.208.0.tgz",
-      "integrity": "sha512-htjs1cDXYXEMwZ1q2vb7wfG3bOW4weWWkKcfT7vqzZKfTXoMH2mPpJIXnPE1PxXerOLXHGUU8qqhfl6LxjlnfQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
-      "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/querystring-builder": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/property-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-      "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-      "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-      "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz",
-      "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.208.0.tgz",
-      "integrity": "sha512-ZDmwOLNiBKfvtN1M2eG2bItw0+4hKDU/XKqB+yVI9Uo29o4XwtQ4Br7HixTlPYJAavmM1cCch8PVvnwngYAKPA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-      "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.208.0.tgz",
-      "integrity": "sha512-4SGPAs7ZtG9AUYknJNkZTs+ww1cpdcPth5te+R/dN4anUbqtL2qvmbdZJ+8rzdAZKndXu0huKE1OZrR3COLciw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/url-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-      "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.208.0.tgz",
-      "integrity": "sha512-nR6S6aZqlr//Sy3+2J7G2mn5XG1ELBBTswvbp6kCo5BK9v/kESuzsHC5b6f3xzl/TY4JSG8Aj+h7x+kZHfKwwg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-base64-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.208.0.tgz",
-      "integrity": "sha512-tCkSexa90loq8yU+BKAX5WIVQGq8IM/DdFhFphQd1azgOIBYxafA/aVw9mDY+to0mq4QRHiUwmUsmzLWEFSDJg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz",
-      "integrity": "sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.208.0.tgz",
-      "integrity": "sha512-T7V3TTc+NdcHgITo8yMUDs/qR0wfPjURUrCixHPtqYkqvhoF6YrHUAoCbOcz7SG/Tsm2GgSKAHB4ip9D2QLg4g==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codebuild/node_modules/fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-      "dev": true,
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.208.0.tgz",
-      "integrity": "sha512-+guT9SC1n/eJ5cdrruCXs4q8q/eoeqSF2siGDyE7+0QMaUbkwWBWJkv6jjxHSVvfLkLkQIn2foJ4gaRj23qXRQ==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.211.0.tgz",
+      "integrity": "sha512-SoinZ+k1TgY/99dUZ2S+FH+sXG3+BaFaSd98if0dygTqIftq9ctaRbDQFss64hdrqu6Qpuvak4XhqaRMaQOr2A==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.208.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-node": "3.208.0",
+        "@aws-sdk/client-sts": "3.211.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.211.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
         "@aws-sdk/middleware-content-length": "3.208.0",
         "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.208.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.209.0",
         "@aws-sdk/middleware-host-header": "3.208.0",
         "@aws-sdk/middleware-logger": "3.208.0",
         "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
         "@aws-sdk/middleware-serde": "3.208.0",
         "@aws-sdk/middleware-signing": "3.208.0",
         "@aws-sdk/middleware-stack": "3.208.0",
         "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/node-http-handler": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/url-parser": "3.208.0",
         "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "@aws-sdk/util-waiter": "3.208.0",
@@ -1097,708 +347,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
-      "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.208.0.tgz",
-      "integrity": "sha512-3e6kEFtuxqZVv1cLGbXFAytTPzR1GpctKITEtJR0MFy3pzj8ttbybrHe0F8z2AqAtDhna1i3u1WVZa+LK3gE9Q==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sts": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.208.0.tgz",
-      "integrity": "sha512-xmPxI/vW0YVm2YhmIfdTQYY8b8dvzP0ordgooDlzAZVj5KnpZLVzQUxin5EqVcZYFJp6qEkVwmFK03QLy9fYOw==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-node": "3.208.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
-        "@aws-sdk/middleware-sdk-sts": "3.208.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.208.0.tgz",
-      "integrity": "sha512-eLwI7rjk3AJj/S8PqRcUi9iBD+cTm1Nzu1CmYyeiwU6YbJLe5/2CrhW1wjkOGleE+aD967U1TWiB18tsx6fj+w==",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz",
-      "integrity": "sha512-FB+KUSpZc03wVTXxGnMmgtaP0sJOv0D7oyogHb7wcf5b7RjjwqoaeUcJHTdKRZaW6e1foLk3/L9uebxiWefDbQ==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.208.0.tgz",
-      "integrity": "sha512-z4Bk42FQefBzS1SZ6/4gsAFE7tQhEoDmSUrFVSDu/9WwvGpFMnFfHLTBhivlcAHjc/eQ/hiWYLnQ8vahqhHl8w==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.208.0.tgz",
-      "integrity": "sha512-AhsUj4046wMnxrPunNVEuddOIb//KsaicRqucw1Pb/UqszDRO4hYWkw7pL10MPIqjHBwuXYZ3vjDZrIhIWMn7A==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.208.0",
-        "@aws-sdk/credential-provider-sso": "3.208.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.208.0.tgz",
-      "integrity": "sha512-KYoxlpDzvhw6v0ae0TgIGPP52HJUHQGI3yImhAZZTz0Nh5B0zd2stip+p36sCYRW6V+TJ5mo5minwqDmYe8oXg==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.208.0",
-        "@aws-sdk/credential-provider-ini": "3.208.0",
-        "@aws-sdk/credential-provider-process": "3.208.0",
-        "@aws-sdk/credential-provider-sso": "3.208.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.208.0.tgz",
-      "integrity": "sha512-ExvFSJB/pVV+/BXIvFR9dgoGxWWnF6uqIw1hfpWCh28UDwsOQdbfUKblMovUfPDBUw67Laqy3mtiY37Jyo/EUQ==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.208.0.tgz",
-      "integrity": "sha512-GVUBmSG8eO4oXy5XpslAgVUBimEVBYmyCdwrwED79ey/7NWfkIVt46VZQapWyAJsarKW+VFpx7BYnam9YBR6hA==",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.208.0.tgz",
-      "integrity": "sha512-7wtrdEr8uvDr5t0stimrXGsW4G+TQyluZ9OucCCY0HXgNihmnk1BIu+COuOSxRtFXHwCh4rIPaVE1ABG2Mq24g==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
-      "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/querystring-builder": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/hash-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz",
-      "integrity": "sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz",
-      "integrity": "sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz",
-      "integrity": "sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz",
-      "integrity": "sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz",
-      "integrity": "sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.208.0.tgz",
-      "integrity": "sha512-JAcN2e3PKWGcNX7run/jP6xJ7w2m15a2CpVrfMtka9p/I/3qnqB86jGUs/3Iv04FEqgXq7KTHbFBg8CndsaHEw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/service-error-classification": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.208.0.tgz",
-      "integrity": "sha512-lFVodZHYLF7puXgNZ1m5ycKbyCPp79nqI+pkRXl066ZtZWzCW8+JKCaLjF3jfXlnvg6foPDJdxUvt0VU5EddGg==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
-      "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.208.0.tgz",
-      "integrity": "sha512-cMSWhg8xOrxZw04EYKEQQQ7RT+03rigS4KS3Uy6x/M+jFyoM+sRiY/7376sJCwlpvKH2xJIVpwPbKk/uz4j4DA==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz",
-      "integrity": "sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz",
-      "integrity": "sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.208.0.tgz",
-      "integrity": "sha512-htjs1cDXYXEMwZ1q2vb7wfG3bOW4weWWkKcfT7vqzZKfTXoMH2mPpJIXnPE1PxXerOLXHGUU8qqhfl6LxjlnfQ==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
-      "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/querystring-builder": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/property-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-      "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-      "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-      "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz",
-      "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.208.0.tgz",
-      "integrity": "sha512-ZDmwOLNiBKfvtN1M2eG2bItw0+4hKDU/XKqB+yVI9Uo29o4XwtQ4Br7HixTlPYJAavmM1cCch8PVvnwngYAKPA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-      "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.208.0.tgz",
-      "integrity": "sha512-4SGPAs7ZtG9AUYknJNkZTs+ww1cpdcPth5te+R/dN4anUbqtL2qvmbdZJ+8rzdAZKndXu0huKE1OZrR3COLciw==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/url-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-      "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.208.0.tgz",
-      "integrity": "sha512-nR6S6aZqlr//Sy3+2J7G2mn5XG1ELBBTswvbp6kCo5BK9v/kESuzsHC5b6f3xzl/TY4JSG8Aj+h7x+kZHfKwwg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-base64-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.208.0.tgz",
-      "integrity": "sha512-tCkSexa90loq8yU+BKAX5WIVQGq8IM/DdFhFphQd1azgOIBYxafA/aVw9mDY+to0mq4QRHiUwmUsmzLWEFSDJg==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz",
-      "integrity": "sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.208.0.tgz",
-      "integrity": "sha512-T7V3TTc+NdcHgITo8yMUDs/qR0wfPjURUrCixHPtqYkqvhoF6YrHUAoCbOcz7SG/Tsm2GgSKAHB4ip9D2QLg4g==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-waiter": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.208.0.tgz",
-      "integrity": "sha512-DEMVnoZXLUXeakBDMe9IhZ8VQCVf/5cMlNtE+4EpSVvH8CEE0Qfc0nDjrTYEkLpAIZWRL3tpHx61MMKvgCirXA==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
@@ -1843,17 +391,676 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.40.0.tgz",
+      "integrity": "sha512-S7LzLvNuwuf0q7r4q7zqGzxd/W2xYsn8cpZ90MMb3ObolhbkLySrikUJujmXae8k+2/KFCOr+FVC0YLrATSUgQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso": {
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.41.0.tgz",
+      "integrity": "sha512-xDvcy7wv3KdHhOpl5fZN+Ydw+dHBmsCZwMFI1ZdJVCSGO+ZKgl5KVWi1LCif6vjZP1pUuGl44oDOZz1ACqOzTg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.40.0",
+        "@aws-sdk/fetch-http-handler": "3.40.0",
+        "@aws-sdk/hash-node": "3.40.0",
+        "@aws-sdk/invalid-dependency": "3.40.0",
+        "@aws-sdk/middleware-content-length": "3.40.0",
+        "@aws-sdk/middleware-host-header": "3.40.0",
+        "@aws-sdk/middleware-logger": "3.40.0",
+        "@aws-sdk/middleware-retry": "3.40.0",
+        "@aws-sdk/middleware-serde": "3.40.0",
+        "@aws-sdk/middleware-stack": "3.40.0",
+        "@aws-sdk/middleware-user-agent": "3.40.0",
+        "@aws-sdk/node-config-provider": "3.40.0",
+        "@aws-sdk/node-http-handler": "3.40.0",
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/smithy-client": "3.41.0",
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/url-parser": "3.40.0",
+        "@aws-sdk/util-base64-browser": "3.37.0",
+        "@aws-sdk/util-base64-node": "3.37.0",
+        "@aws-sdk/util-body-length-browser": "3.37.0",
+        "@aws-sdk/util-body-length-node": "3.37.0",
+        "@aws-sdk/util-user-agent-browser": "3.40.0",
+        "@aws-sdk/util-user-agent-node": "3.40.0",
+        "@aws-sdk/util-utf8-browser": "3.37.0",
+        "@aws-sdk/util-utf8-node": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sts": {
+      "version": "3.43.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.43.0.tgz",
+      "integrity": "sha512-4CKYimjhIEixVtJH0Y8FR5FXc7zIepZtfScy8QHgH+DERXm/YL5cuUbkJiL6ZRTpek0vztVvE+mNSQU0z1eXag==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.40.0",
+        "@aws-sdk/credential-provider-node": "3.41.0",
+        "@aws-sdk/fetch-http-handler": "3.40.0",
+        "@aws-sdk/hash-node": "3.40.0",
+        "@aws-sdk/invalid-dependency": "3.40.0",
+        "@aws-sdk/middleware-content-length": "3.40.0",
+        "@aws-sdk/middleware-host-header": "3.40.0",
+        "@aws-sdk/middleware-logger": "3.40.0",
+        "@aws-sdk/middleware-retry": "3.40.0",
+        "@aws-sdk/middleware-sdk-sts": "3.40.0",
+        "@aws-sdk/middleware-serde": "3.40.0",
+        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/middleware-stack": "3.40.0",
+        "@aws-sdk/middleware-user-agent": "3.40.0",
+        "@aws-sdk/node-config-provider": "3.40.0",
+        "@aws-sdk/node-http-handler": "3.40.0",
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/smithy-client": "3.41.0",
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/url-parser": "3.40.0",
+        "@aws-sdk/util-base64-browser": "3.37.0",
+        "@aws-sdk/util-base64-node": "3.37.0",
+        "@aws-sdk/util-body-length-browser": "3.37.0",
+        "@aws-sdk/util-body-length-node": "3.37.0",
+        "@aws-sdk/util-user-agent-browser": "3.40.0",
+        "@aws-sdk/util-user-agent-node": "3.40.0",
+        "@aws-sdk/util-utf8-browser": "3.37.0",
+        "@aws-sdk/util-utf8-node": "3.37.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.40.0.tgz",
+      "integrity": "sha512-QYy6J2k31QL6J74hPBfptnLW1kQYdN+xjwH4UQ1mv7EUhRoJN9ZY2soStJowFy4at6IIOOVWbyG5dyqvrbEovg==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/util-config-provider": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.40.0.tgz",
+      "integrity": "sha512-qHZdf2vxhzZkSygjw2I4SEYFL2dMZxxYvO4QlkqQouKY81OVxs/j69oiNCjPasQzGz5jaZZKI8xEAIfkSyr1lg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.40.0.tgz",
+      "integrity": "sha512-Ty/wVa+BQrCFrP06AGl5S1CeLifDt68YrlYXUnkRn603SX4DvxBgVO7XFeDH58G8ziDCiqxfmVl4yjbncPPeSw==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.40.0",
+        "@aws-sdk/property-provider": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/url-parser": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.41.0.tgz",
+      "integrity": "sha512-98CGEHg7Tb6HxK5ZIdbAcijvD3IpLe0ddse1xMe/Ilhjz770FS/L2UNprOP6PZTqrSfBffiMrvfThUSuUaTlIQ==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.40.0",
+        "@aws-sdk/credential-provider-imds": "3.40.0",
+        "@aws-sdk/credential-provider-sso": "3.41.0",
+        "@aws-sdk/credential-provider-web-identity": "3.41.0",
+        "@aws-sdk/property-provider": "3.40.0",
+        "@aws-sdk/shared-ini-file-loader": "3.37.0",
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/util-credentials": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.41.0.tgz",
+      "integrity": "sha512-5FW6+wNJgyDCsbAd+mLm/1DBTDkyIYOMVzcxbr6Vi3pM4UrMFdeLdAP62edYW8usg78Xg+c6vaAoEv/M3zkS0Q==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.40.0",
+        "@aws-sdk/credential-provider-imds": "3.40.0",
+        "@aws-sdk/credential-provider-ini": "3.41.0",
+        "@aws-sdk/credential-provider-process": "3.40.0",
+        "@aws-sdk/credential-provider-sso": "3.41.0",
+        "@aws-sdk/credential-provider-web-identity": "3.41.0",
+        "@aws-sdk/property-provider": "3.40.0",
+        "@aws-sdk/shared-ini-file-loader": "3.37.0",
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/util-credentials": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.40.0.tgz",
+      "integrity": "sha512-qsaNCDesW2GasDbzpeOA371gxugi05JWxt3EKonLbUfkGKBK7kmmL6EgLIxZuNm2/Ve4RS07PKp8yBGm4xIx9w==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.40.0",
+        "@aws-sdk/shared-ini-file-loader": "3.37.0",
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/util-credentials": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.41.0.tgz",
+      "integrity": "sha512-9s7SWu3RVIQ/MTcBCt35EMzxNQm3avivrbpSOKfJwxR5L+oNKPsV+gSqMlkNZGwOVJyUicIsZGcq/4ON6CjrOg==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.41.0",
+        "@aws-sdk/property-provider": "3.40.0",
+        "@aws-sdk/shared-ini-file-loader": "3.37.0",
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/util-credentials": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.41.0.tgz",
+      "integrity": "sha512-VqvVoEh9C8xTXl4stKyJC5IKQhS8g1Gi5k6B9HPHLIxFRRfKxkE73DT4pMN6npnus7o0yi0MTFGQFQGYSrFO2g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.40.0.tgz",
+      "integrity": "sha512-w1HiZromoU+/bbEo89uO81l6UO/M+c2uOMnXntZqe6t3ZHUUUo3AbvhKh0QGVFqRQa+Oi0+95KqWmTHa72/9Iw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/querystring-builder": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/util-base64-browser": "3.37.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/hash-node": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.40.0.tgz",
+      "integrity": "sha512-yOXXK85DdGDktdnQtXgMdaVKii4wtMjEhJ1mrvx2A9nMFNaPhxvERkVVIUKSWlJRa9ZujOw5jWOx8d2R51/Kjg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/util-buffer-from": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.40.0.tgz",
+      "integrity": "sha512-axIWtDwCBDDqEgAJipX1FB1ZNpWYXquVwKDMo+7G+ftPBZ4FEq4M1ELhXJL3hhNJ9ZmCQzv+4F6Wnt8dwuzUaQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.37.0.tgz",
+      "integrity": "sha512-XLjA/a6AuGnCvcJZLsMTy2jxF2upgGhqCCkoIJgLlzzXHSihur13KcmPvW/zcaGnCRj0SvKWXiJHl4vDlW75VQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.40.0.tgz",
+      "integrity": "sha512-sybAJb8v7I/vvL08R3+TI/XDAg9gybQTZ2treC24Ap4+jAOz4QBTHJPMKaUlEeFlMUcq4rj6/u2897ebYH6opw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.40.0.tgz",
+      "integrity": "sha512-/wocR7JFOLM7/+BQM1DgAd6KCFYcdxYu1P7AhI451GlVNuYa5f89zh7p0gt3SRC6monI5lXgpL7RudhDm8fTrA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.40.0.tgz",
+      "integrity": "sha512-19kx0Xg5ymVRKoupmhdmfTBkROcv3DZj508agpyG2YAo0abOObMlIP4Jltg0VD4PhNjGzNh0jFGJnvhjdwv4/A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.40.0.tgz",
+      "integrity": "sha512-SMUJrukugLL7YJE5X8B2ToukxMWMPwnf7jAFr84ptycCe8bdWv8x8klQ3EtVWpyqochtNlbTi6J/tTQBniUX7A==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/service-error-classification": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.40.0.tgz",
+      "integrity": "sha512-TcrbCvj1PkabFZiNczT3yePZtuEm2fAIw1OVnQyLcF2KW+p62Hv5YkK4MPOfx3LA/0lzjOUO1RNl2x7gzV443Q==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/property-provider": "3.40.0",
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/signature-v4": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.40.0.tgz",
+      "integrity": "sha512-uOWfZjlAoBy6xPqp0d4ka83WNNbEVCWn9WwfqBUXThyoTdTooYSpXe5y2YzN0BJa8b+tEZTyWpgamnBpFLp47g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.40.0.tgz",
+      "integrity": "sha512-RqK5nPbfma0qInMvjtpVkDYY/KkFS6EKlOv3DWTdxbXJ4YuOxgKiuUromhmBUoyjFag0JO7LUWod07H+/DawoA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.40.0",
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/signature-v4": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.40.0.tgz",
+      "integrity": "sha512-hby9HvESUYJxpdALX+6Dn2LPmS5jtMVurGB/+j3MWOvIcDYB4bcSXgVRvXzYnTKwbSupIdbX9zOE2ZAx2SJpUQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.40.0.tgz",
+      "integrity": "sha512-dzC2fxWnanetFJ1oYgil8df3N36bR1yc/OCOpbdfQNiUk1FrXiCXqH5rHNO8zCvnwJAj8GHFwpFGd9a2Qube2w==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.40.0.tgz",
+      "integrity": "sha512-AmokjgUDECG8osoMfdRsPNweqI+L1pn4bYGk5iTLmzbBi0o4ot0U1FdX8Rf0qJZZwS4t1TXc3s8/PDVknmPxKg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.40.0",
+        "@aws-sdk/shared-ini-file-loader": "3.37.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.40.0.tgz",
+      "integrity": "sha512-qjda6IbxDhbYr8NHmrMurKkbjgLUkfTMVgagDErDK24Nm3Dn5VaO6J4n6c0Q4OLHlmFaRcUfZSTrOo5DAubqCw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.40.0",
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/querystring-builder": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/property-provider": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.40.0.tgz",
+      "integrity": "sha512-Mx4lkShjsYRwW9ujHA1pcnuubrWQ4kF5/DXWNfUiXuSIO/0Lojp1qTLheyBm4vzkJIlx5umyP6NvRAUkEHSN4Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.40.0.tgz",
+      "integrity": "sha512-f4ea7/HZkjpvGBrnRIuzc/bhrExWrgDv7eulj4htPukZGHdTqSJD3Jk8lEXWvFuX2vUKQDGhEhCDsqup7YWJQQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.40.0.tgz",
+      "integrity": "sha512-gO24oipnNaxJRBXB7lhLfa96vIMOd8gtMBqJTjelTjS2e1ZP1YY12CNKKTWwafSk8Ge021erZAG/YTOaXGpv+g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/util-uri-escape": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.40.0.tgz",
+      "integrity": "sha512-XZIyaKQIiZAM6zelCBcsLHhVDOLafi7XIOd3jy6SymGN8ajj3HqUJ/vdQ5G6ISTk18OrqgqcCOI9oNzv+nrBcA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.40.0.tgz",
+      "integrity": "sha512-c8btKmkvjXczWudXubGdbO3JgmjySBUVC/gCrZDNfwNGsG8RYJJQYYcnmt1gWjelUZsgMDl/2PIzxTlxVF91rA==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.37.0.tgz",
+      "integrity": "sha512-+vRBSlfa48R9KL7DpQt3dsu5/+5atjRgoCISblWo3SLpjrx41pKcjKneo7a1u0aP1Xc2oG2TfIyqTWZuOXsmEQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.40.0.tgz",
+      "integrity": "sha512-Q1GNZJRCS3W2qsRtDsX/b6EOSfMXfr6TW46N3LnLTGYZ3KAN2SOSJ1DsW59AuGpEZyRmOhJ9L/Q5U403+bZMXQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.37.0",
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/util-hex-encoding": "3.37.0",
+        "@aws-sdk/util-uri-escape": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.41.0.tgz",
+      "integrity": "sha512-ldhS0Pf3v6yHCd//kk5DvKcdyeUkKEwxNDRanAp+ekTW68J3XcYgKaPC9sNDhVTDH1zrywTvtEz5zWHEvXjQow==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/types": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
+      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/url-parser": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.40.0.tgz",
+      "integrity": "sha512-HwNV+HX7bHgLk5FzTOgdXANsC0SeVz5PMC4Nh+TLz2IoeQnrw4H8dsA4YNonncjern5oC5veKRjQeOoCL5SlSQ==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.37.0.tgz",
+      "integrity": "sha512-tClmH1uYelqWT43xxmnOsVFbCQJiIwizp6y4E109G2LIof07inxrO0L8nbwBpjhugVplx6NZr9IaqTFqbdM1gA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.37.0.tgz",
+      "integrity": "sha512-aY3mXdbEajruRi9CHgq/heM89R+Gectj/Xrs1naewmamaN8NJrvjDm3s+cw//lqqSOW903LYHXDgm7wvCzUnFA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.37.0.tgz",
+      "integrity": "sha512-aa3SBwjLwImuJoE4+hxDIWQ9REz3UFb3p7KFPe9qopdXb/yB12RTcbrXVb4whUux4i4mO6KRij0ZNjFZrjrKPg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.40.0.tgz",
+      "integrity": "sha512-NjZGrA4mqhpr6gkVCAUweurP0Z9d3vFyXJCtulC0BFbpKAnKCf/crSK56NwUaNhAEMCkSuBvjRFzkbfT+HO8bA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.37.0.tgz",
+      "integrity": "sha512-tn5UpfaeM+rZWqynoNqB8lwtcAXil5YYO3HLGH9himpWAdft/2Z7LK6bsYDpctaAI1WHgMDcL0bw3Id04ZUbhA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.37.0.tgz",
+      "integrity": "sha512-8pKf4YJTELP5lm/CEgYw2atyJBB1RWWqFa0sZx6YJmTlOtLF5G6raUdAi4iDa2hldGt2B6IAdIIyuusT8zeU8Q==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.40.0.tgz",
+      "integrity": "sha512-C69sTI26bV2EprTv3DTXu9XP7kD9Wu4YVPBzqztOYArd2GDYw3w+jS8SEg3XRbjAKY/mOPZ2Thw4StjpZlWZiA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.40.0.tgz",
+      "integrity": "sha512-cjIzd0hRZFTTh7iLJD6Bciu++Em1iaM1clyG02xRl0JD5DEtDSR1zO02uu+AeM7GSLGOxIvwOkK2j8ySPAOmBA==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.37.0.tgz",
+      "integrity": "sha512-tuiOxzfqet1kKGYzlgpMGfhr64AHJnYsFx2jZiH/O6Yq8XQg43ryjQlbJlim/K/XHGNzY0R+nabeJg34q3Ua1g==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.37.0.tgz",
+      "integrity": "sha512-fUAgd7UTCULL36j9/vnXHxVhxvswnq23mYgTCIT8NQ7wHN30q2a89ym1e9DwGeQkJEBOkOcKLn6nsMsN7YQMDQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-waiter": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.40.0.tgz",
+      "integrity": "sha512-jdxwNEZdID49ZvyAnxaeNm5w2moIfMLOwj/q6TxKlxYoXMs16FQWkhyfGue0vEASzchS49ewbyt+KBqpT31Ebg==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.209.0.tgz",
-      "integrity": "sha512-FKRsG93bqM4Ra+wOgq8Rbg6z7enR5bvPdckfZE5bNVq0mUGCFxcCfurvpAxp4dAtQgLZRhMXIPc1B3wAB/UnmA==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.211.0.tgz",
+      "integrity": "sha512-Wk7bqhhdMtys/dd97ap0GMfJcGzlYrlWsGzK5uNF+TqvOcpZ4NIk7Ui0+NCtSfrM8CajfQRamwPKs0N/8sFIiQ==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.209.0",
+        "@aws-sdk/client-sts": "3.211.0",
         "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.211.0",
         "@aws-sdk/eventstream-serde-browser": "3.208.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.208.0",
         "@aws-sdk/eventstream-serde-node": "3.208.0",
@@ -1891,7 +1098,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
         "@aws-sdk/util-stream-browser": "3.208.0",
         "@aws-sdk/util-stream-node": "3.208.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
@@ -1905,727 +1112,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
-      "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.209.0.tgz",
-      "integrity": "sha512-rh9QktLCOVTbvDzCb0ikSe4Q1I35Wxcx5XZ7k1J+2ze54FOBfCr3vOwcQpo5tpYWEe1Ysbt3gvA8RAqj9oDFdw==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.209.0.tgz",
-      "integrity": "sha512-zWlM+9/JbshEgrG79KZlqYusUziKiKqe8vRlvQ9wcuEHNbQnAri4UvObEKik+7YpTBeP3mR+US1T71G0PqJByw==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.209.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-sdk-sts": "3.208.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
-      "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz",
-      "integrity": "sha512-FB+KUSpZc03wVTXxGnMmgtaP0sJOv0D7oyogHb7wcf5b7RjjwqoaeUcJHTdKRZaW6e1foLk3/L9uebxiWefDbQ==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
-      "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.209.0.tgz",
-      "integrity": "sha512-aszuzkKIg7V+tCcq8RNpr1dAyECXWvJRAvzlmE5ZBYtjHMIX/qVAqSP4sfLNeI/Qagyj7W0TeVA1XVRjkivjYA==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.209.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.209.0.tgz",
-      "integrity": "sha512-R0kV6B+GxbfdSowf/6eeEAHZC6X7P/IxJ/o/gCuMmAOixge0e6AWVgCvrd0cg0togJHWbmoYSuUyqWPIMxM1Yg==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-ini": "3.209.0",
-        "@aws-sdk/credential-provider-process": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.209.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz",
-      "integrity": "sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.209.0.tgz",
-      "integrity": "sha512-SKzUYOn2EFx58+iU1KihGLtBz9s1jolWUQ6HYxOy4AkWnZVGUt9Vb4mIo6wB07nSSUgYRxOSYn21SKvvBzpc2g==",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.209.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/token-providers": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.208.0.tgz",
-      "integrity": "sha512-7wtrdEr8uvDr5t0stimrXGsW4G+TQyluZ9OucCCY0HXgNihmnk1BIu+COuOSxRtFXHwCh4rIPaVE1ABG2Mq24g==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
-      "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/querystring-builder": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/hash-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz",
-      "integrity": "sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz",
-      "integrity": "sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz",
-      "integrity": "sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz",
-      "integrity": "sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz",
-      "integrity": "sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
-      "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/service-error-classification": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.208.0.tgz",
-      "integrity": "sha512-lFVodZHYLF7puXgNZ1m5ycKbyCPp79nqI+pkRXl066ZtZWzCW8+JKCaLjF3jfXlnvg6foPDJdxUvt0VU5EddGg==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
-      "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.208.0.tgz",
-      "integrity": "sha512-cMSWhg8xOrxZw04EYKEQQQ7RT+03rigS4KS3Uy6x/M+jFyoM+sRiY/7376sJCwlpvKH2xJIVpwPbKk/uz4j4DA==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz",
-      "integrity": "sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz",
-      "integrity": "sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
-      "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
-      "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/querystring-builder": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/property-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-      "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-      "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-      "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz",
-      "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-      "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
-      "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/url-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-      "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
-      "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
-      "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
-      "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz",
-      "integrity": "sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
-      "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-waiter": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.208.0.tgz",
-      "integrity": "sha512-DEMVnoZXLUXeakBDMe9IhZ8VQCVf/5cMlNtE+4EpSVvH8CEE0Qfc0nDjrTYEkLpAIZWRL3tpHx61MMKvgCirXA==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
@@ -2671,7 +1157,19 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sso": {
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.40.0.tgz",
+      "integrity": "sha512-S7LzLvNuwuf0q7r4q7zqGzxd/W2xYsn8cpZ90MMb3ObolhbkLySrikUJujmXae8k+2/KFCOr+FVC0YLrATSUgQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso": {
       "version": "3.41.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.41.0.tgz",
       "integrity": "sha512-xDvcy7wv3KdHhOpl5fZN+Ydw+dHBmsCZwMFI1ZdJVCSGO+ZKgl5KVWi1LCif6vjZP1pUuGl44oDOZz1ACqOzTg==",
@@ -2709,528 +1207,7 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.209.0.tgz",
-      "integrity": "sha512-KSmT181IcE32lqoZsS0h400qiL/BSQ84DS1iPOqP0NkLcgnvmOkKygVpYjTql2xSUWLQBwPNFihYJ+jmAj3HtQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
-      "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
-      "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
-      "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
-      "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/querystring-builder": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/hash-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz",
-      "integrity": "sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz",
-      "integrity": "sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz",
-      "integrity": "sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz",
-      "integrity": "sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz",
-      "integrity": "sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
-      "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/service-error-classification": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
-      "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz",
-      "integrity": "sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz",
-      "integrity": "sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
-      "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
-      "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/querystring-builder": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/property-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-      "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-      "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-      "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz",
-      "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-      "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
-      "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/url-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-      "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
-      "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
-      "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
-      "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz",
-      "integrity": "sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
-      "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts": {
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sts": {
       "version": "3.43.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.43.0.tgz",
       "integrity": "sha512-4CKYimjhIEixVtJH0Y8FR5FXc7zIepZtfScy8QHgH+DERXm/YL5cuUbkJiL6ZRTpek0vztVvE+mNSQU0z1eXag==",
@@ -3273,7 +1250,7 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/config-resolver": {
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/config-resolver": {
       "version": "3.40.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.40.0.tgz",
       "integrity": "sha512-QYy6J2k31QL6J74hPBfptnLW1kQYdN+xjwH4UQ1mv7EUhRoJN9ZY2soStJowFy4at6IIOOVWbyG5dyqvrbEovg==",
@@ -3287,7 +1264,7 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-env": {
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.40.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.40.0.tgz",
       "integrity": "sha512-qHZdf2vxhzZkSygjw2I4SEYFL2dMZxxYvO4QlkqQouKY81OVxs/j69oiNCjPasQzGz5jaZZKI8xEAIfkSyr1lg==",
@@ -3300,7 +1277,7 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-imds": {
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-imds": {
       "version": "3.40.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.40.0.tgz",
       "integrity": "sha512-Ty/wVa+BQrCFrP06AGl5S1CeLifDt68YrlYXUnkRn603SX4DvxBgVO7XFeDH58G8ziDCiqxfmVl4yjbncPPeSw==",
@@ -3315,7 +1292,7 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-ini": {
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.41.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.41.0.tgz",
       "integrity": "sha512-98CGEHg7Tb6HxK5ZIdbAcijvD3IpLe0ddse1xMe/Ilhjz770FS/L2UNprOP6PZTqrSfBffiMrvfThUSuUaTlIQ==",
@@ -3334,7 +1311,7 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-node": {
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.41.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.41.0.tgz",
       "integrity": "sha512-5FW6+wNJgyDCsbAd+mLm/1DBTDkyIYOMVzcxbr6Vi3pM4UrMFdeLdAP62edYW8usg78Xg+c6vaAoEv/M3zkS0Q==",
@@ -3355,7 +1332,7 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-process": {
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.40.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.40.0.tgz",
       "integrity": "sha512-qsaNCDesW2GasDbzpeOA371gxugi05JWxt3EKonLbUfkGKBK7kmmL6EgLIxZuNm2/Ve4RS07PKp8yBGm4xIx9w==",
@@ -3370,7 +1347,7 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-sso": {
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.41.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.41.0.tgz",
       "integrity": "sha512-9s7SWu3RVIQ/MTcBCt35EMzxNQm3avivrbpSOKfJwxR5L+oNKPsV+gSqMlkNZGwOVJyUicIsZGcq/4ON6CjrOg==",
@@ -3386,7 +1363,7 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-web-identity": {
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.41.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.41.0.tgz",
       "integrity": "sha512-VqvVoEh9C8xTXl4stKyJC5IKQhS8g1Gi5k6B9HPHLIxFRRfKxkE73DT4pMN6npnus7o0yi0MTFGQFQGYSrFO2g==",
@@ -3397,6 +1374,700 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.40.0.tgz",
+      "integrity": "sha512-w1HiZromoU+/bbEo89uO81l6UO/M+c2uOMnXntZqe6t3ZHUUUo3AbvhKh0QGVFqRQa+Oi0+95KqWmTHa72/9Iw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/querystring-builder": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/util-base64-browser": "3.37.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/hash-node": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.40.0.tgz",
+      "integrity": "sha512-yOXXK85DdGDktdnQtXgMdaVKii4wtMjEhJ1mrvx2A9nMFNaPhxvERkVVIUKSWlJRa9ZujOw5jWOx8d2R51/Kjg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/util-buffer-from": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.40.0.tgz",
+      "integrity": "sha512-axIWtDwCBDDqEgAJipX1FB1ZNpWYXquVwKDMo+7G+ftPBZ4FEq4M1ELhXJL3hhNJ9ZmCQzv+4F6Wnt8dwuzUaQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.37.0.tgz",
+      "integrity": "sha512-XLjA/a6AuGnCvcJZLsMTy2jxF2upgGhqCCkoIJgLlzzXHSihur13KcmPvW/zcaGnCRj0SvKWXiJHl4vDlW75VQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.40.0.tgz",
+      "integrity": "sha512-sybAJb8v7I/vvL08R3+TI/XDAg9gybQTZ2treC24Ap4+jAOz4QBTHJPMKaUlEeFlMUcq4rj6/u2897ebYH6opw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.40.0.tgz",
+      "integrity": "sha512-/wocR7JFOLM7/+BQM1DgAd6KCFYcdxYu1P7AhI451GlVNuYa5f89zh7p0gt3SRC6monI5lXgpL7RudhDm8fTrA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.40.0.tgz",
+      "integrity": "sha512-19kx0Xg5ymVRKoupmhdmfTBkROcv3DZj508agpyG2YAo0abOObMlIP4Jltg0VD4PhNjGzNh0jFGJnvhjdwv4/A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.40.0.tgz",
+      "integrity": "sha512-SMUJrukugLL7YJE5X8B2ToukxMWMPwnf7jAFr84ptycCe8bdWv8x8klQ3EtVWpyqochtNlbTi6J/tTQBniUX7A==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/service-error-classification": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.40.0.tgz",
+      "integrity": "sha512-TcrbCvj1PkabFZiNczT3yePZtuEm2fAIw1OVnQyLcF2KW+p62Hv5YkK4MPOfx3LA/0lzjOUO1RNl2x7gzV443Q==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/property-provider": "3.40.0",
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/signature-v4": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.40.0.tgz",
+      "integrity": "sha512-uOWfZjlAoBy6xPqp0d4ka83WNNbEVCWn9WwfqBUXThyoTdTooYSpXe5y2YzN0BJa8b+tEZTyWpgamnBpFLp47g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.40.0.tgz",
+      "integrity": "sha512-RqK5nPbfma0qInMvjtpVkDYY/KkFS6EKlOv3DWTdxbXJ4YuOxgKiuUromhmBUoyjFag0JO7LUWod07H+/DawoA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.40.0",
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/signature-v4": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.40.0.tgz",
+      "integrity": "sha512-hby9HvESUYJxpdALX+6Dn2LPmS5jtMVurGB/+j3MWOvIcDYB4bcSXgVRvXzYnTKwbSupIdbX9zOE2ZAx2SJpUQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.40.0.tgz",
+      "integrity": "sha512-dzC2fxWnanetFJ1oYgil8df3N36bR1yc/OCOpbdfQNiUk1FrXiCXqH5rHNO8zCvnwJAj8GHFwpFGd9a2Qube2w==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.40.0.tgz",
+      "integrity": "sha512-AmokjgUDECG8osoMfdRsPNweqI+L1pn4bYGk5iTLmzbBi0o4ot0U1FdX8Rf0qJZZwS4t1TXc3s8/PDVknmPxKg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.40.0",
+        "@aws-sdk/shared-ini-file-loader": "3.37.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.40.0.tgz",
+      "integrity": "sha512-qjda6IbxDhbYr8NHmrMurKkbjgLUkfTMVgagDErDK24Nm3Dn5VaO6J4n6c0Q4OLHlmFaRcUfZSTrOo5DAubqCw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.40.0",
+        "@aws-sdk/protocol-http": "3.40.0",
+        "@aws-sdk/querystring-builder": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/property-provider": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.40.0.tgz",
+      "integrity": "sha512-Mx4lkShjsYRwW9ujHA1pcnuubrWQ4kF5/DXWNfUiXuSIO/0Lojp1qTLheyBm4vzkJIlx5umyP6NvRAUkEHSN4Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.40.0.tgz",
+      "integrity": "sha512-f4ea7/HZkjpvGBrnRIuzc/bhrExWrgDv7eulj4htPukZGHdTqSJD3Jk8lEXWvFuX2vUKQDGhEhCDsqup7YWJQQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.40.0.tgz",
+      "integrity": "sha512-gO24oipnNaxJRBXB7lhLfa96vIMOd8gtMBqJTjelTjS2e1ZP1YY12CNKKTWwafSk8Ge021erZAG/YTOaXGpv+g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/util-uri-escape": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.40.0.tgz",
+      "integrity": "sha512-XZIyaKQIiZAM6zelCBcsLHhVDOLafi7XIOd3jy6SymGN8ajj3HqUJ/vdQ5G6ISTk18OrqgqcCOI9oNzv+nrBcA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.40.0.tgz",
+      "integrity": "sha512-c8btKmkvjXczWudXubGdbO3JgmjySBUVC/gCrZDNfwNGsG8RYJJQYYcnmt1gWjelUZsgMDl/2PIzxTlxVF91rA==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.37.0.tgz",
+      "integrity": "sha512-+vRBSlfa48R9KL7DpQt3dsu5/+5atjRgoCISblWo3SLpjrx41pKcjKneo7a1u0aP1Xc2oG2TfIyqTWZuOXsmEQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.40.0.tgz",
+      "integrity": "sha512-Q1GNZJRCS3W2qsRtDsX/b6EOSfMXfr6TW46N3LnLTGYZ3KAN2SOSJ1DsW59AuGpEZyRmOhJ9L/Q5U403+bZMXQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.37.0",
+        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/util-hex-encoding": "3.37.0",
+        "@aws-sdk/util-uri-escape": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.41.0.tgz",
+      "integrity": "sha512-ldhS0Pf3v6yHCd//kk5DvKcdyeUkKEwxNDRanAp+ekTW68J3XcYgKaPC9sNDhVTDH1zrywTvtEz5zWHEvXjQow==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/types": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
+      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/url-parser": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.40.0.tgz",
+      "integrity": "sha512-HwNV+HX7bHgLk5FzTOgdXANsC0SeVz5PMC4Nh+TLz2IoeQnrw4H8dsA4YNonncjern5oC5veKRjQeOoCL5SlSQ==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.37.0.tgz",
+      "integrity": "sha512-tClmH1uYelqWT43xxmnOsVFbCQJiIwizp6y4E109G2LIof07inxrO0L8nbwBpjhugVplx6NZr9IaqTFqbdM1gA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.37.0.tgz",
+      "integrity": "sha512-aY3mXdbEajruRi9CHgq/heM89R+Gectj/Xrs1naewmamaN8NJrvjDm3s+cw//lqqSOW903LYHXDgm7wvCzUnFA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.37.0.tgz",
+      "integrity": "sha512-aa3SBwjLwImuJoE4+hxDIWQ9REz3UFb3p7KFPe9qopdXb/yB12RTcbrXVb4whUux4i4mO6KRij0ZNjFZrjrKPg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.40.0.tgz",
+      "integrity": "sha512-NjZGrA4mqhpr6gkVCAUweurP0Z9d3vFyXJCtulC0BFbpKAnKCf/crSK56NwUaNhAEMCkSuBvjRFzkbfT+HO8bA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.37.0.tgz",
+      "integrity": "sha512-tn5UpfaeM+rZWqynoNqB8lwtcAXil5YYO3HLGH9himpWAdft/2Z7LK6bsYDpctaAI1WHgMDcL0bw3Id04ZUbhA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.37.0.tgz",
+      "integrity": "sha512-8pKf4YJTELP5lm/CEgYw2atyJBB1RWWqFa0sZx6YJmTlOtLF5G6raUdAi4iDa2hldGt2B6IAdIIyuusT8zeU8Q==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.40.0.tgz",
+      "integrity": "sha512-C69sTI26bV2EprTv3DTXu9XP7kD9Wu4YVPBzqztOYArd2GDYw3w+jS8SEg3XRbjAKY/mOPZ2Thw4StjpZlWZiA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.40.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.40.0.tgz",
+      "integrity": "sha512-cjIzd0hRZFTTh7iLJD6Bciu++Em1iaM1clyG02xRl0JD5DEtDSR1zO02uu+AeM7GSLGOxIvwOkK2j8ySPAOmBA==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.37.0.tgz",
+      "integrity": "sha512-tuiOxzfqet1kKGYzlgpMGfhr64AHJnYsFx2jZiH/O6Yq8XQg43ryjQlbJlim/K/XHGNzY0R+nabeJg34q3Ua1g==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.37.0.tgz",
+      "integrity": "sha512-fUAgd7UTCULL36j9/vnXHxVhxvswnq23mYgTCIT8NQ7wHN30q2a89ym1e9DwGeQkJEBOkOcKLn6nsMsN7YQMDQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.37.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-waiter": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.40.0.tgz",
+      "integrity": "sha512-jdxwNEZdID49ZvyAnxaeNm5w2moIfMLOwj/q6TxKlxYoXMs16FQWkhyfGue0vEASzchS49ewbyt+KBqpT31Ebg==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.40.0",
+        "@aws-sdk/types": "3.40.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.211.0.tgz",
+      "integrity": "sha512-Wuo3ZYPy9L+OixlZ7/wM1BbPBdC22xO/a8z/J1sgQZiRDl80Ax+jf1u17D91xdZJGH0hTU5AlvEY7mHP0y/hAw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.211.0.tgz",
+      "integrity": "sha512-oJ+5ROykVsXpBFpWUfSUYHz/RcTjsZPri6CIY+wQmEFDAOxTsgxd7l8VkqX1r/U/QiK/xDXuK+Z7MurywXS+rQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.211.0.tgz",
+      "integrity": "sha512-39/PMIKLEaRUztx3m4I0x9SCnqTStaQuqIabAK/wk0uy+O2p32sv7eacRrGjZWHngqdsK7S1s/LSFErYzzIvkw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.211.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-sdk-sts": "3.208.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-signing": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
+      "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz",
+      "integrity": "sha512-FB+KUSpZc03wVTXxGnMmgtaP0sJOv0D7oyogHb7wcf5b7RjjwqoaeUcJHTdKRZaW6e1foLk3/L9uebxiWefDbQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
+      "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.211.0.tgz",
+      "integrity": "sha512-kFekBDGX3tMsbEBjpCHt2dp5hx7xBN0d7v+fNXky4fB61bNUxcLNpXkTgDIqRyMzEje3Jov9Be9Qgqb8ud0Fiw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.208.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.211.0",
+        "@aws-sdk/credential-provider-web-identity": "3.208.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.211.0.tgz",
+      "integrity": "sha512-RWDitzHmZOfrfTZCnL8nOLQgYgawAAw8IF5pqeNjcN9TZ/pR64B9pusTYD7a+uVDB8kb9vMU767g89ts2pqmfQ==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.208.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/credential-provider-ini": "3.211.0",
+        "@aws-sdk/credential-provider-process": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.211.0",
+        "@aws-sdk/credential-provider-web-identity": "3.208.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz",
+      "integrity": "sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.211.0.tgz",
+      "integrity": "sha512-S8ciHRypUCi0Uz0D80yVGkWmvpCBCvkEaj+IO0LdYX05GDnH/B44DA8UQ0pfAJqLy5BeSO5snKVRKSPzxNtUGw==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.211.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/token-providers": "3.211.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.208.0.tgz",
+      "integrity": "sha512-7wtrdEr8uvDr5t0stimrXGsW4G+TQyluZ9OucCCY0HXgNihmnk1BIu+COuOSxRtFXHwCh4rIPaVE1ABG2Mq24g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/endpoint-cache": {
@@ -3411,19 +2082,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/endpoint-cache/node_modules/mnemonist": {
-      "version": "0.38.3",
-      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
-      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
-      "dependencies": {
-        "obliterator": "^1.6.1"
-      }
-    },
-    "node_modules/@aws-sdk/endpoint-cache/node_modules/obliterator": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
-      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
-    },
     "node_modules/@aws-sdk/eventstream-codec": {
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.208.0.tgz",
@@ -3433,25 +2091,6 @@
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/util-hex-encoding": "3.201.0",
         "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-codec/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-codec/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-browser": {
@@ -3467,14 +2106,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/eventstream-serde-browser/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.208.0.tgz",
@@ -3483,14 +2114,6 @@
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3508,14 +2131,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/eventstream-serde-node/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/eventstream-serde-universal": {
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.208.0.tgz",
@@ -3529,24 +2144,16 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/eventstream-serde-universal/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.40.0.tgz",
-      "integrity": "sha512-w1HiZromoU+/bbEo89uO81l6UO/M+c2uOMnXntZqe6t3ZHUUUo3AbvhKh0QGVFqRQa+Oi0+95KqWmTHa72/9Iw==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
+      "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/querystring-builder": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-base64-browser": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/querystring-builder": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/hash-blob-browser": {
@@ -3560,25 +2167,17 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@aws-sdk/hash-blob-browser/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.40.0.tgz",
-      "integrity": "sha512-yOXXK85DdGDktdnQtXgMdaVKii4wtMjEhJ1mrvx2A9nMFNaPhxvERkVVIUKSWlJRa9ZujOw5jWOx8d2R51/Kjg==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz",
+      "integrity": "sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-buffer-from": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/hash-stream-node": {
@@ -3593,32 +2192,24 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/hash-stream-node/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.40.0.tgz",
-      "integrity": "sha512-axIWtDwCBDDqEgAJipX1FB1ZNpWYXquVwKDMo+7G+ftPBZ4FEq4M1ELhXJL3hhNJ9ZmCQzv+4F6Wnt8dwuzUaQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz",
+      "integrity": "sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==",
       "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.37.0.tgz",
-      "integrity": "sha512-XLjA/a6AuGnCvcJZLsMTy2jxF2upgGhqCCkoIJgLlzzXHSihur13KcmPvW/zcaGnCRj0SvKWXiJHl4vDlW75VQ==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/md5-js": {
@@ -3630,57 +2221,6 @@
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
@@ -3698,48 +2238,17 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/protocol-http": {
+    "node_modules/@aws-sdk/middleware-content-length": {
       "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz",
+      "integrity": "sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==",
       "dependencies": {
+        "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.40.0.tgz",
-      "integrity": "sha512-sybAJb8v7I/vvL08R3+TI/XDAg9gybQTZ2treC24Ap4+jAOz4QBTHJPMKaUlEeFlMUcq4rj6/u2897ebYH6opw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint": {
@@ -3761,223 +2270,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.208.0.tgz",
-      "integrity": "sha512-RSbqxZ/oVBY7VvIjwm8ZrpcI4jd+oZZJVXNA2H++J12yEVGNLYOFXZzUatq+Z8ryfuugdsvfMYvVA64qzT8rQw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.209.0.tgz",
+      "integrity": "sha512-ZBWYhTBfdc/bUNB1N4jL8ZW7NmKTkdowbZHTlxtXi8ySzzn+qlD+XosIEbXqrVR9sYxSVC3kwsQvADxHzKGixw==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.208.0",
+        "@aws-sdk/config-resolver": "3.209.0",
         "@aws-sdk/endpoint-cache": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.208.0.tgz",
-      "integrity": "sha512-eLwI7rjk3AJj/S8PqRcUi9iBD+cTm1Nzu1CmYyeiwU6YbJLe5/2CrhW1wjkOGleE+aD967U1TWiB18tsx6fj+w==",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-      "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
-      "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-      "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-      "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/url-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-      "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -3993,26 +2293,6 @@
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4033,48 +2313,17 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/protocol-http": {
+    "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz",
+      "integrity": "sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==",
       "dependencies": {
+        "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.40.0.tgz",
-      "integrity": "sha512-/wocR7JFOLM7/+BQM1DgAd6KCFYcdxYu1P7AhI451GlVNuYa5f89zh7p0gt3SRC6monI5lXgpL7RudhDm8fTrA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
@@ -4089,24 +2338,16 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.40.0.tgz",
-      "integrity": "sha512-19kx0Xg5ymVRKoupmhdmfTBkROcv3DZj508agpyG2YAo0abOObMlIP4Jltg0VD4PhNjGzNh0jFGJnvhjdwv4/A==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz",
+      "integrity": "sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==",
       "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
@@ -4122,39 +2363,20 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.40.0.tgz",
-      "integrity": "sha512-SMUJrukugLL7YJE5X8B2ToukxMWMPwnf7jAFr84ptycCe8bdWv8x8klQ3EtVWpyqochtNlbTi6J/tTQBniUX7A==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
+      "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/service-error-classification": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/service-error-classification": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-middleware": "3.208.0",
+        "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
@@ -4172,10 +2394,26 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/protocol-http": {
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
       "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.208.0.tgz",
+      "integrity": "sha512-lFVodZHYLF7puXgNZ1m5ycKbyCPp79nqI+pkRXl066ZtZWzCW8+JKCaLjF3jfXlnvg6foPDJdxUvt0VU5EddGg==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.208.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/signature-v4": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
+      "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
       "dependencies": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
@@ -4184,55 +2422,20 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
+    "node_modules/@aws-sdk/middleware-signing": {
       "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.208.0.tgz",
+      "integrity": "sha512-cMSWhg8xOrxZw04EYKEQQQ7RT+03rigS4KS3Uy6x/M+jFyoM+sRiY/7376sJCwlpvKH2xJIVpwPbKk/uz4j4DA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/signature-v4": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-middleware": "3.208.0",
+        "tslib": "^2.3.1"
+      },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.40.0.tgz",
-      "integrity": "sha512-TcrbCvj1PkabFZiNczT3yePZtuEm2fAIw1OVnQyLcF2KW+p62Hv5YkK4MPOfx3LA/0lzjOUO1RNl2x7gzV443Q==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.40.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/signature-v4": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.40.0.tgz",
-      "integrity": "sha512-uOWfZjlAoBy6xPqp0d4ka83WNNbEVCWn9WwfqBUXThyoTdTooYSpXe5y2YzN0BJa8b+tEZTyWpgamnBpFLp47g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.40.0.tgz",
-      "integrity": "sha512-RqK5nPbfma0qInMvjtpVkDYY/KkFS6EKlOv3DWTdxbXJ4YuOxgKiuUromhmBUoyjFag0JO7LUWod07H+/DawoA==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/signature-v4": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
@@ -4247,148 +2450,142 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
+    "node_modules/@aws-sdk/middleware-stack": {
       "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz",
+      "integrity": "sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.40.0.tgz",
-      "integrity": "sha512-hby9HvESUYJxpdALX+6Dn2LPmS5jtMVurGB/+j3MWOvIcDYB4bcSXgVRvXzYnTKwbSupIdbX9zOE2ZAx2SJpUQ==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.40.0.tgz",
-      "integrity": "sha512-dzC2fxWnanetFJ1oYgil8df3N36bR1yc/OCOpbdfQNiUk1FrXiCXqH5rHNO8zCvnwJAj8GHFwpFGd9a2Qube2w==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz",
+      "integrity": "sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.40.0.tgz",
-      "integrity": "sha512-AmokjgUDECG8osoMfdRsPNweqI+L1pn4bYGk5iTLmzbBi0o4ot0U1FdX8Rf0qJZZwS4t1TXc3s8/PDVknmPxKg==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
+      "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.40.0.tgz",
-      "integrity": "sha512-qjda6IbxDhbYr8NHmrMurKkbjgLUkfTMVgagDErDK24Nm3Dn5VaO6J4n6c0Q4OLHlmFaRcUfZSTrOo5DAubqCw==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
+      "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/querystring-builder": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/abort-controller": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/querystring-builder": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.40.0.tgz",
-      "integrity": "sha512-Mx4lkShjsYRwW9ujHA1pcnuubrWQ4kF5/DXWNfUiXuSIO/0Lojp1qTLheyBm4vzkJIlx5umyP6NvRAUkEHSN4Q==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
+      "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
       "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.40.0.tgz",
-      "integrity": "sha512-f4ea7/HZkjpvGBrnRIuzc/bhrExWrgDv7eulj4htPukZGHdTqSJD3Jk8lEXWvFuX2vUKQDGhEhCDsqup7YWJQQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
+      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
       "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.40.0.tgz",
-      "integrity": "sha512-gO24oipnNaxJRBXB7lhLfa96vIMOd8gtMBqJTjelTjS2e1ZP1YY12CNKKTWwafSk8Ge021erZAG/YTOaXGpv+g==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
+      "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
       "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-uri-escape": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.40.0.tgz",
-      "integrity": "sha512-XZIyaKQIiZAM6zelCBcsLHhVDOLafi7XIOd3jy6SymGN8ajj3HqUJ/vdQ5G6ISTk18OrqgqcCOI9oNzv+nrBcA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
+      "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.40.0.tgz",
-      "integrity": "sha512-c8btKmkvjXczWudXubGdbO3JgmjySBUVC/gCrZDNfwNGsG8RYJJQYYcnmt1gWjelUZsgMDl/2PIzxTlxVF91rA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz",
+      "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw==",
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.37.0.tgz",
-      "integrity": "sha512-+vRBSlfa48R9KL7DpQt3dsu5/+5atjRgoCISblWo3SLpjrx41pKcjKneo7a1u0aP1Xc2oG2TfIyqTWZuOXsmEQ==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
+      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.40.0.tgz",
-      "integrity": "sha512-Q1GNZJRCS3W2qsRtDsX/b6EOSfMXfr6TW46N3LnLTGYZ3KAN2SOSJ1DsW59AuGpEZyRmOhJ9L/Q5U403+bZMXQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
+      "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-hex-encoding": "3.37.0",
-        "@aws-sdk/util-uri-escape": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.208.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
@@ -4414,94 +2611,25 @@
         }
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-      "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.41.0.tgz",
-      "integrity": "sha512-ldhS0Pf3v6yHCd//kk5DvKcdyeUkKEwxNDRanAp+ekTW68J3XcYgKaPC9sNDhVTDH1zrywTvtEz5zWHEvXjQow==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
+      "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.209.0.tgz",
-      "integrity": "sha512-MMtL/yD98SxjejcZYghLN4qhC1TDNeHjnzb+zBcXANxgh5m+QdhERsZkDGU8QiEo+DL6M2HKbwyXu82z89sqnQ==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.211.0.tgz",
+      "integrity": "sha512-dxdUT+JKCl9krmBQde1HeV6rwYP+ZTBkfx5vIa3PdfDI7XljRBf1XdE0mS18eSURfQA7v969Y5sJ6/rFyjT/QA==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.209.0",
+        "@aws-sdk/client-sso-oidc": "3.211.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
@@ -4511,31 +2639,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/property-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-      "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
+    "node_modules/@aws-sdk/types": {
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
       "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
@@ -4543,22 +2647,14 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.40.0.tgz",
-      "integrity": "sha512-HwNV+HX7bHgLk5FzTOgdXANsC0SeVz5PMC4Nh+TLz2IoeQnrw4H8dsA4YNonncjern5oC5veKRjQeOoCL5SlSQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
+      "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/querystring-parser": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
@@ -4604,41 +2700,10 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-base64/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-browser": {
+    "node_modules/@aws-sdk/util-base64-node/node_modules/@aws-sdk/is-array-buffer": {
       "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.37.0.tgz",
-      "integrity": "sha512-tClmH1uYelqWT43xxmnOsVFbCQJiIwizp6y4E109G2LIof07inxrO0L8nbwBpjhugVplx6NZr9IaqTFqbdM1gA==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.37.0.tgz",
-      "integrity": "sha512-aY3mXdbEajruRi9CHgq/heM89R+Gectj/Xrs1naewmamaN8NJrvjDm3s+cw//lqqSOW903LYHXDgm7wvCzUnFA==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.37.0.tgz",
+      "integrity": "sha512-XLjA/a6AuGnCvcJZLsMTy2jxF2upgGhqCCkoIJgLlzzXHSihur13KcmPvW/zcaGnCRj0SvKWXiJHl4vDlW75VQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4646,7 +2711,7 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-buffer-from": {
+    "node_modules/@aws-sdk/util-base64-node/node_modules/@aws-sdk/util-buffer-from": {
       "version": "3.37.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.37.0.tgz",
       "integrity": "sha512-aa3SBwjLwImuJoE4+hxDIWQ9REz3UFb3p7KFPe9qopdXb/yB12RTcbrXVb4whUux4i4mO6KRij0ZNjFZrjrKPg==",
@@ -4658,15 +2723,46 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.40.0.tgz",
-      "integrity": "sha512-NjZGrA4mqhpr6gkVCAUweurP0Z9d3vFyXJCtulC0BFbpKAnKCf/crSK56NwUaNhAEMCkSuBvjRFzkbfT+HO8bA==",
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-credentials": {
@@ -4681,10 +2777,21 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-credentials/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.37.0.tgz",
+      "integrity": "sha512-+vRBSlfa48R9KL7DpQt3dsu5/+5atjRgoCISblWo3SLpjrx41pKcjKneo7a1u0aP1Xc2oG2TfIyqTWZuOXsmEQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.208.0.tgz",
-      "integrity": "sha512-i4cA074pycou1BPr7axFMiK3iHv+Tzjl/ZiN3Yc0BQDLWC9AQdrNodB4WAKnn4a4fWgA/MadfzKXnW1oltSzIg==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
+      "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
       "dependencies": {
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/types": "3.208.0",
@@ -4695,34 +2802,14 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/@aws-sdk/property-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-      "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.208.0.tgz",
-      "integrity": "sha512-y9dENqcmiUb7/D3uwJsE/fV+RZ9CUc/cs4OcofO81sU29xz8Fg/XQarjSdGVZMTnrDd190GXymMcB4qpOYhtPw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
+      "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
@@ -4731,168 +2818,10 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.208.0.tgz",
-      "integrity": "sha512-eLwI7rjk3AJj/S8PqRcUi9iBD+cTm1Nzu1CmYyeiwU6YbJLe5/2CrhW1wjkOGleE+aD967U1TWiB18tsx6fj+w==",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.208.0.tgz",
-      "integrity": "sha512-z4Bk42FQefBzS1SZ6/4gsAFE7tQhEoDmSUrFVSDu/9WwvGpFMnFfHLTBhivlcAHjc/eQ/hiWYLnQ8vahqhHl8w==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.208.0.tgz",
-      "integrity": "sha512-htjs1cDXYXEMwZ1q2vb7wfG3bOW4weWWkKcfT7vqzZKfTXoMH2mPpJIXnPE1PxXerOLXHGUU8qqhfl6LxjlnfQ==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/property-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-      "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-      "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.208.0.tgz",
-      "integrity": "sha512-ZDmwOLNiBKfvtN1M2eG2bItw0+4hKDU/XKqB+yVI9Uo29o4XwtQ4Br7HixTlPYJAavmM1cCch8PVvnwngYAKPA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-      "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/url-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-      "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.208.0.tgz",
-      "integrity": "sha512-4tJNlsZ2wpaQVxQ+AwXGmUk3lLWBrqK4lpJYITJ1C6Y8VZF/yqjeH+mNGQifMzO3T4dzCuGBCUKJ1HUCmGApCw==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.211.0.tgz",
+      "integrity": "sha512-XvtGV2sDmS8ZQMnztWQlVxPJ90iTL13IhHfOiDGp3gGzSLow8pNzBfw3+xmxFAtu0Q2XfSmFb/F/vyPt2SzcnQ==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -4901,9 +2830,9 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.208.0.tgz",
-      "integrity": "sha512-FGJA07iEbC883bAaw0qtDrly5Y+1nR3ic+OOzGX2AsSgaeVAc1j8Lgg3br7ofBbr8p81ec6zN4syy4v7V0Wb0A==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.211.0.tgz",
+      "integrity": "sha512-FY0h897WFltaUBF5aedLCBP2OlxN0aIqrInAa7aYGz3HsUTl97liHTii34bZrMJQHxmfcKBXAsjV1jJGc2orLw==",
       "dependencies": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
@@ -4912,23 +2841,15 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.37.0.tgz",
-      "integrity": "sha512-tn5UpfaeM+rZWqynoNqB8lwtcAXil5YYO3HLGH9himpWAdft/2Z7LK6bsYDpctaAI1WHgMDcL0bw3Id04ZUbhA==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
@@ -4966,81 +2887,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
-      "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/querystring-builder": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-      "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
     "node_modules/@aws-sdk/util-stream-node": {
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.208.0.tgz",
@@ -5055,90 +2901,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
-      "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
-      "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/querystring-builder": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-      "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/util-uri-escape": {
+    "node_modules/@aws-sdk/util-uri-escape": {
       "version": "3.201.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
       "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
@@ -5149,71 +2912,68 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.37.0.tgz",
-      "integrity": "sha512-8pKf4YJTELP5lm/CEgYw2atyJBB1RWWqFa0sZx6YJmTlOtLF5G6raUdAi4iDa2hldGt2B6IAdIIyuusT8zeU8Q==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.40.0.tgz",
-      "integrity": "sha512-C69sTI26bV2EprTv3DTXu9XP7kD9Wu4YVPBzqztOYArd2GDYw3w+jS8SEg3XRbjAKY/mOPZ2Thw4StjpZlWZiA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz",
+      "integrity": "sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/types": "3.208.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.40.0.tgz",
-      "integrity": "sha512-cjIzd0hRZFTTh7iLJD6Bciu++Em1iaM1clyG02xRl0JD5DEtDSR1zO02uu+AeM7GSLGOxIvwOkK2j8ySPAOmBA==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
+      "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.37.0.tgz",
-      "integrity": "sha512-tuiOxzfqet1kKGYzlgpMGfhr64AHJnYsFx2jZiH/O6Yq8XQg43ryjQlbJlim/K/XHGNzY0R+nabeJg34q3Ua1g==",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.37.0.tgz",
-      "integrity": "sha512-fUAgd7UTCULL36j9/vnXHxVhxvswnq23mYgTCIT8NQ7wHN30q2a89ym1e9DwGeQkJEBOkOcKLn6nsMsN7YQMDQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.40.0.tgz",
-      "integrity": "sha512-jdxwNEZdID49ZvyAnxaeNm5w2moIfMLOwj/q6TxKlxYoXMs16FQWkhyfGue0vEASzchS49ewbyt+KBqpT31Ebg==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.208.0.tgz",
+      "integrity": "sha512-DEMVnoZXLUXeakBDMe9IhZ8VQCVf/5cMlNtE+4EpSVvH8CEE0Qfc0nDjrTYEkLpAIZWRL3tpHx61MMKvgCirXA==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/abort-controller": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
@@ -5476,9 +3236,9 @@
       "dev": true
     },
     "node_modules/@ipld/car": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.0.0.tgz",
-      "integrity": "sha512-JyJ5vGEIyheqxmJKa81eQdd9tScOKpkO1wcGQPsm/DbV87n0wT7KvzaFOLSZCcPoq23+C5u+GIwFV+CBUVBGOw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.0.1.tgz",
+      "integrity": "sha512-YPXr1TztVmTPE4MerjKpFMuIll73MqvEakzWDMqj4uGJnwkY+tE0SlBGmqkMSofOgVMQAxZ6JtuRA93WlTzb8w==",
       "dependencies": {
         "@ipld/dag-cbor": "^8.0.0",
         "cborg": "^1.9.0",
@@ -5643,14 +3403,14 @@
       }
     },
     "node_modules/@serverless-stack/cli": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/cli/-/cli-1.17.1.tgz",
-      "integrity": "sha512-fwv1tHki4U+6hOSdvfO32axP4hySW0DEvSQDkWudofxGSQ0nimeNCIMqce49pEp2gfJscHr2Qv71hGAbEpJhhQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/cli/-/cli-1.18.0.tgz",
+      "integrity": "sha512-W2Bh6Tk+X4QzyN9KS+rTrWXSGxlalfxUafGy8TDjyZIa3TILgAl2HgHH/kB3NdfTxkxfrOdFcNL89DdbutHapw==",
       "dev": true,
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2-alpha": "2.50.0-alpha.0",
-        "@serverless-stack/core": "1.17.1",
-        "@serverless-stack/resources": "1.17.1",
+        "@serverless-stack/core": "1.18.0",
+        "@serverless-stack/resources": "1.18.0",
         "aws-cdk": "2.50.0",
         "aws-cdk-lib": "2.50.0",
         "aws-sdk": "^2.1110.0",
@@ -5673,9 +3433,9 @@
       }
     },
     "node_modules/@serverless-stack/core": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/core/-/core-1.17.1.tgz",
-      "integrity": "sha512-gR+cxYJdb4cDcyh5Pw6USjVKzOuD+1iLA+yr1Y5dB30U181y8PE+NpAjv9D2LQzLQBGfnyWVFqlZvYSr+8Sd0A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/core/-/core-1.18.0.tgz",
+      "integrity": "sha512-Qg30siJrmH3/cAchs+svkcrNObUv1dUy1mOJ0aNoQXXsvxXQryxNi9Kouswn7szGvOGDcioNvn2+V08IEzmrjQ==",
       "dev": true,
       "dependencies": {
         "@serverless-stack/aws-lambda-ric": "^2.0.13",
@@ -5702,7 +3462,7 @@
         "immer": "^9.0.7",
         "js-yaml": "^4.1.0",
         "kysely": "^0.21.3",
-        "kysely-codegen": "^0.6.0",
+        "kysely-codegen": "^0.6.1",
         "kysely-data-api": "^0.1.2",
         "log4js": "^6.3.0",
         "picomatch": "^2.3.0",
@@ -5720,9 +3480,9 @@
       }
     },
     "node_modules/@serverless-stack/node": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/node/-/node-1.17.1.tgz",
-      "integrity": "sha512-hfByLWtjhMrvOZ5dkkjX1Z5oht/U9iUWeVc7doXrwqtQTbRBnWgKx/v19sNGwt+TW+zrfY1dLeP5RTwt/me4bA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/node/-/node-1.18.0.tgz",
+      "integrity": "sha512-S5tKbz9i/P8YS5TqZD1XYSmi22n+H3qbCjyaGXBSB/P/i5VuHiJJCP7l1eBO/p+aa7VwdNJgVUy/Yp4NaxSiqA==",
       "dependencies": {
         "@aws-sdk/client-lambda": "3.43.0",
         "@aws-sdk/client-ssm": "3.43.0",
@@ -5739,9 +3499,9 @@
       }
     },
     "node_modules/@serverless-stack/resources": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/resources/-/resources-1.17.1.tgz",
-      "integrity": "sha512-CG/0fIU2PCQGEPLChCkOPTl96LF+tv/ccb8CuWG0sIslyk1KMUC5tYvlA8OyP1xcV+DQv0oMkOWvbbdlRgmNrg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/resources/-/resources-1.18.0.tgz",
+      "integrity": "sha512-SKZKZCqlOhlDKJLnLi5wQfkaaEejaezHkePVtvclYv3u+IC7SEOf8BqOXsXnKuupANYw4uIQ+vujaK92zzzv1g==",
       "dev": true,
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2-alpha": "2.50.0-alpha.0",
@@ -5749,7 +3509,7 @@
         "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.50.0-alpha.0",
         "@aws-cdk/aws-appsync-alpha": "2.50.0-alpha.0",
         "@aws-sdk/client-codebuild": "^3.169.0",
-        "@serverless-stack/core": "1.17.1",
+        "@serverless-stack/core": "1.18.0",
         "archiver": "^5.3.0",
         "aws-cdk-lib": "2.50.0",
         "chalk": "^4.1.0",
@@ -5816,9 +3576,9 @@
       }
     },
     "node_modules/@types/dockerode": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.12.tgz",
-      "integrity": "sha512-9dCtVq6Nr4XkkJmjyiDYOfZWVQ8MpJ35RZNawJYFLjd1VuaFLboDoIcyar23BkpMLeYzp6+vT8Vp3GHjhhlY+w==",
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.13.tgz",
+      "integrity": "sha512-0q7tbf2z/4cP3hmgENF9y4TsaIpeEP2Hzx3W8ABEdNvDiflIeN8O1oKIbfdOUg2+II5U9QRMTVRHF7PkIR45OA==",
       "dev": true,
       "dependencies": {
         "@types/docker-modem": "*",
@@ -5917,14 +3677,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.1.tgz",
-      "integrity": "sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.43.0.tgz",
+      "integrity": "sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/type-utils": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/type-utils": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -5950,12 +3710,12 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.42.1.tgz",
-      "integrity": "sha512-qona75z2MLpeZADEuCet5Pwvh1g/0cWScEEDy43chuUPc4klgDiwz5hLFk5dHcjFEETSYQHRPYiiHKW24EMPjw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.43.0.tgz",
+      "integrity": "sha512-WkT637CumTJbm/hRbFfnHBMgfUYTKr08LitVsD7gQId7bi6rnkx3pu3jac67lmp5ObW4MpJ9SNFZAIOUB/Qbsw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.42.1"
+        "@typescript-eslint/utils": "5.43.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5969,14 +3729,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.1.tgz",
-      "integrity": "sha512-kAV+NiNBWVQDY9gDJDToTE/NO8BHi4f6b7zTsVAJoTkmB/zlfOpiEVBzHOKtlgTndCKe8vj9F/PuolemZSh50Q==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.43.0.tgz",
+      "integrity": "sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -5996,13 +3756,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.1.tgz",
-      "integrity": "sha512-QAZY/CBP1Emx4rzxurgqj3rUinfsh/6mvuKbLNMfJMMKYLRBfweus8brgXF8f64ABkIZ3zdj2/rYYtF8eiuksQ==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.43.0.tgz",
+      "integrity": "sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1"
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/visitor-keys": "5.43.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6013,13 +3773,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.1.tgz",
-      "integrity": "sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.43.0.tgz",
+      "integrity": "sha512-K21f+KY2/VvYggLf5Pk4tgBOPs2otTaIHy2zjclo7UZGLyFH86VfUOm5iq+OtDtxq/Zwu2I3ujDBykVW4Xtmtg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/typescript-estree": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -6040,9 +3800,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.1.tgz",
-      "integrity": "sha512-Qrco9dsFF5lhalz+lLFtxs3ui1/YfC6NdXu+RAGBa8uSfn01cjO7ssCsjIsUs484vny9Xm699FSKwpkCcqwWwA==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.43.0.tgz",
+      "integrity": "sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6053,13 +3813,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.1.tgz",
-      "integrity": "sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.43.0.tgz",
+      "integrity": "sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/visitor-keys": "5.43.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -6100,16 +3860,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.1.tgz",
-      "integrity": "sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.43.0.tgz",
+      "integrity": "sha512-8nVpA6yX0sCjf7v/NDfeaOlyaIIqL7OaIGOWSPFqUKK59Gnumd3Wa+2l8oAaYO2lk0sO+SbWFWRSvhu8gLGv4A==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -6126,12 +3886,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.1.tgz",
-      "integrity": "sha512-LOQtSF4z+hejmpUvitPlc4hA7ERGoj2BVkesOcG91HCn8edLGUXbTrErmutmPbl8Bo9HjAvOO/zBKQHExXNA2A==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.43.0.tgz",
+      "integrity": "sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.1",
+        "@typescript-eslint/types": "5.43.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -6143,24 +3903,24 @@
       }
     },
     "node_modules/@ucanto/client": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-3.0.1.tgz",
-      "integrity": "sha512-rK0M3kqLHlvLTp6P9jyqjSOdzGbulawxzfFOh0cV4D6FLLjpHwNq5NpXZ7n6AbQ7H1EQeWla/gNgLKVGWXKrMQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-3.0.2.tgz",
+      "integrity": "sha512-viYv/fLPvH/POFIfVoIaK4B8KSYIBLNZeVFCdnhSbS4/m6t3h4G0Z7GMjNyP1mZG/CGjAOmHxeNvMUr0sNCyVQ==",
       "dependencies": {
-        "@ucanto/interface": "^3.0.0",
-        "multiformats": "^10.0.0"
+        "@ucanto/interface": "^3.0.1",
+        "multiformats": "^10.0.2"
       }
     },
     "node_modules/@ucanto/core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-3.0.1.tgz",
-      "integrity": "sha512-DoCIfczxo6bikOUFA/5RS6QTC52Xz2Dfija5rsWmRj+vP8LIvuuuNhHZbgDEmXtSRVyvoVQeAxxxHmWWrVtoAQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-3.0.2.tgz",
+      "integrity": "sha512-TEVCqAM/3v4fXLuZcIBgQZrPwD53yqoXqwmSChhd420FikFGkkAeWvj6JT6oR4VmCuiIPK5FnukaE2LL5h0Ekg==",
       "dependencies": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-ucan": "^2.0.0",
-        "@ucanto/interface": "^3.0.0",
-        "multiformats": "^10.0.0"
+        "@ucanto/interface": "^3.0.1",
+        "multiformats": "^10.0.2"
       }
     },
     "node_modules/@ucanto/interface": {
@@ -6173,49 +3933,49 @@
       }
     },
     "node_modules/@ucanto/principal": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-3.0.0.tgz",
-      "integrity": "sha512-7CwVbYQc+CdWta+lNuI6vRjVT+GkPwf2VQVXFBm8i4fQomFOTmOq8I/Be3TBS9N2OaIbL7b/eKy1WBdMMzfz5g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-3.0.1.tgz",
+      "integrity": "sha512-0U0EF2ddfR55LKKc7FkzTkH8OFvjZvEeRqMkyV5FyeSsFEF7lXhgEXZrNgggK2zlriXjYC9VVCpPhsGb4cI72g==",
       "dependencies": {
         "@ipld/dag-ucan": "^2.0.0",
         "@noble/ed25519": "^1.7.1",
-        "@ucanto/interface": "^3.0.0",
-        "multiformats": "^10.0.0",
+        "@ucanto/interface": "^3.0.1",
+        "multiformats": "^10.0.2",
         "one-webcrypto": "^1.0.3"
       }
     },
     "node_modules/@ucanto/server": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/server/-/server-3.0.1.tgz",
-      "integrity": "sha512-PMBb9gPk+5+qKl7bANusPq9xCm2S0dVNIT33EmmtNhXWQSj8nLvWLInnxXYGc+ziyQonPZtDPgKi02uREFEdXw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@ucanto/server/-/server-3.0.4.tgz",
+      "integrity": "sha512-4a5ou5HZ8ymw39EeZ0024nu0JD916xTMpYsS4eXMxpnoWlOjgmoeWZ5e01dEiw5AlfnSa8e9+a0b1dzvSISQxQ==",
       "dependencies": {
-        "@ucanto/core": "^3.0.1",
-        "@ucanto/interface": "^3.0.0",
-        "@ucanto/validator": "^3.0.1"
+        "@ucanto/core": "^3.0.2",
+        "@ucanto/interface": "^3.0.1",
+        "@ucanto/validator": "^3.0.4"
       }
     },
     "node_modules/@ucanto/transport": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-3.0.1.tgz",
-      "integrity": "sha512-stUryA8e6Npkt8RVcxko61gE11+c2Gta+eGzv1XOrWGCk5WqdzequWs/zLxgHxq52EqCWZhLYKQpY5nkrz5UAA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-3.0.2.tgz",
+      "integrity": "sha512-IyfI26VWPxCL2jnGiGP1i6mZblk8QORHzEVt5t+7Pic2k7pANQHoqbveQveRb9a8z6D/UdFogSPQxWYYtKaxWQ==",
       "dependencies": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-cbor": "^8.0.0",
-        "@ucanto/core": "^3.0.1",
-        "@ucanto/interface": "^3.0.0",
-        "multiformats": "^10.0.0"
+        "@ucanto/core": "^3.0.2",
+        "@ucanto/interface": "^3.0.1",
+        "multiformats": "^10.0.2"
       }
     },
     "node_modules/@ucanto/validator": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-3.0.1.tgz",
-      "integrity": "sha512-LVirhuwMPOwATIDwlhGZt7C1BtrKp2+HJ7pALQcbC4+eHYyminniZEAzYjf0/EnjXtDj0SL3jnnBBvmpIJiWDQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-3.0.4.tgz",
+      "integrity": "sha512-JG6y6yWPDUBoJuWP7auwMTZf9SJN9d2e7y/ZbVvluQBZC+WvhLq1Z2cjWCjA21Y2FJxWeI27leBjWzyIsHtYUA==",
       "dependencies": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-cbor": "^8.0.0",
-        "@ucanto/core": "^3.0.1",
-        "@ucanto/interface": "^3.0.0",
-        "multiformats": "^10.0.0"
+        "@ucanto/core": "^3.0.2",
+        "@ucanto/interface": "^3.0.1",
+        "multiformats": "^10.0.2"
       }
     },
     "node_modules/@w3up-api/services": {
@@ -6272,21 +4032,21 @@
       }
     },
     "node_modules/@web3-storage/access": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@web3-storage/access/-/access-4.0.2.tgz",
-      "integrity": "sha512-Y81KX4ZQqkLRHKdX7mvxXw8ZvHnF399NFO1K0MTMcMf6kkDmGExGctsshbRGFGeByzBR/IS5FR57k7AZgQKEXg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@web3-storage/access/-/access-5.0.1.tgz",
+      "integrity": "sha512-s4UuPjwJCIk+dXzGqLTJkUHxF0KVPhnZcWdQavoA+MSr6QCMFbz2ZAz5o1XQWOYMYj02p1c5Gqc8bF/pBCpwEg==",
       "dependencies": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-ucan": "^2.0.1",
         "@noble/ed25519": "^1.7.1",
         "@types/ws": "^8.5.3",
-        "@ucanto/client": "^3.0.1",
-        "@ucanto/core": "^3.0.1",
-        "@ucanto/interface": "^3.0.0",
-        "@ucanto/principal": "^3.0.0",
-        "@ucanto/server": "^3.0.1",
-        "@ucanto/transport": "^3.0.1",
-        "@ucanto/validator": "^3.0.1",
+        "@ucanto/client": "^3.0.2",
+        "@ucanto/core": "^3.0.2",
+        "@ucanto/interface": "^3.0.1",
+        "@ucanto/principal": "^3.0.1",
+        "@ucanto/server": "^3.0.4",
+        "@ucanto/transport": "^3.0.2",
+        "@ucanto/validator": "^3.0.4",
         "@web-std/fetch": "^4.1.0",
         "bigint-mod-arith": "^3.1.2",
         "conf": "^10.1.2",
@@ -6438,9 +4198,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -7301,9 +5061,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1252.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1252.0.tgz",
-      "integrity": "sha512-ayBNGAPhCm/tyWNki24cwPgI8DUm/suKTh2YDB6SrgeROyHJHMTXpj1dVaYXrBrZjRN7erVi5g7pkaxzCt/28A==",
+      "version": "2.1255.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1255.0.tgz",
+      "integrity": "sha512-S3oPXrBVOWquVL1bzH79bz88PgF4GqLcUbIph5yJ+pWW0OKNWGWKW1PDwtWi6ma+8mKXJ1gGKgy6R2hD57AsLw==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -7714,9 +5474,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.5.tgz",
-      "integrity": "sha512-fLBv8wmqtlXqy1Yu+pHzevAIkW6k2K0ZtMujNzWphLsA34vzzg9BHn+5GmZqOJkSA9V7EMKsWrf6K976c1QMjQ==",
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.6.tgz",
+      "integrity": "sha512-XmiD+NWTk9xg31d8MdXgW46bSZd95ELllxjbjdWGyHAtpTw+cf8iG3NibWgTWRnfWfxtcihVa5Pm0gchHiO3JQ==",
       "bin": {
         "cborg": "cli.js"
       }
@@ -7818,10 +5578,13 @@
       "dev": true
     },
     "node_modules/ci-info": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
-      "dev": true
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.6.1.tgz",
+      "integrity": "sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ci-parallel-vars": {
       "version": "1.0.1",
@@ -8175,9 +5938,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.156",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.156.tgz",
-      "integrity": "sha512-BTZ3Kyt++/YFlph/ioqbDhzSKVMqHRHvc99FxU4b705ZP6s2IkDxMLCMinC70USMTJWFbO1p02Egux7sk4q07A==",
+      "version": "10.1.161",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.161.tgz",
+      "integrity": "sha512-+g6J5m6iAdrflfdbKlL1+5/RNyPvOmI+Quua/q85Ak65XuvrGGOTujAXcbQxYGNhwWJj4TCje6SsrJMcVpLfNQ==",
       "dev": true,
       "engines": {
         "node": ">= 14.17.0"
@@ -10171,17 +7934,30 @@
       "dev": true
     },
     "node_modules/fast-jwt": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/fast-jwt/-/fast-jwt-1.7.1.tgz",
-      "integrity": "sha512-HdDR/k2d3qgUHDVwyhzYdHG/EK+IGhDGZFNidlSvCpVIhWMce8UYXUjx8hWEDhvOA032qoCtO1f/d/VcuzWhzA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/fast-jwt/-/fast-jwt-1.7.2.tgz",
+      "integrity": "sha512-OEInypGXJhtURzq9GbFM5KaALUu9+4IV3kJEbWPuqOBN5JBe7A51Tx0CaQYHGC9GNfZnr5npA0lCIMaWiZmz/A==",
       "dependencies": {
         "asn1.js": "^5.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
         "mnemonist": "^0.39.0"
       },
       "engines": {
-        "node": "^18 || ^17 || ^16 || ^14 || ^12"
+        "node": ">=14 <20"
       }
+    },
+    "node_modules/fast-jwt/node_modules/mnemonist": {
+      "version": "0.39.5",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.5.tgz",
+      "integrity": "sha512-FPUtkhtJ0efmEFGpU14x7jGbTB+s18LrzRL2KgoWz9YvcY3cPomz8tih01GbHwnGk/OmkOKfqd/RAQoc8Lm7DQ==",
+      "dependencies": {
+        "obliterator": "^2.0.1"
+      }
+    },
+    "node_modules/fast-jwt/node_modules/obliterator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -10190,11 +7966,14 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
-      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
       "bin": {
-        "xml2js": "cli.js"
+        "fxparser": "src/cli/cli.js"
       },
       "funding": {
         "type": "paypal",
@@ -12576,11 +10355,11 @@
       "dev": true
     },
     "node_modules/mnemonist": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.5.tgz",
-      "integrity": "sha512-FPUtkhtJ0efmEFGpU14x7jGbTB+s18LrzRL2KgoWz9YvcY3cPomz8tih01GbHwnGk/OmkOKfqd/RAQoc8Lm7DQ==",
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
       "dependencies": {
-        "obliterator": "^2.0.1"
+        "obliterator": "^1.6.1"
       }
     },
     "node_modules/mrmime": {
@@ -12897,9 +10676,9 @@
       }
     },
     "node_modules/obliterator": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
-      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
     },
     "node_modules/oidc-token-hash": {
       "version": "5.0.1",
@@ -15207,9 +12986,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -15995,11 +13774,6 @@
         "tslib": "^1.11.1"
       },
       "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        },
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -16008,12 +13782,12 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.40.0.tgz",
-      "integrity": "sha512-S7LzLvNuwuf0q7r4q7zqGzxd/W2xYsn8cpZ90MMb3ObolhbkLySrikUJujmXae8k+2/KFCOr+FVC0YLrATSUgQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
+      "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/chunked-blob-reader": {
@@ -16034,16 +13808,16 @@
       }
     },
     "@aws-sdk/client-codebuild": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-codebuild/-/client-codebuild-3.208.0.tgz",
-      "integrity": "sha512-chw3bztFWvo40zN+QYG8OMMZ8u2esdtLHAohqIm8BRoyL3+KDlAe2BL/Jeu/RTJ9ZNdu47HfeSfwgzKqWFCDaQ==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-codebuild/-/client-codebuild-3.211.0.tgz",
+      "integrity": "sha512-cPmfX5TPMbPerGrOmN0NUewxdteyeVLmTIMnTkl20/LWhrg1sFS86/11xNiwYNxcpr6qQgnDY7KtdYVqnYsGiA==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.208.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-node": "3.208.0",
+        "@aws-sdk/client-sts": "3.211.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.211.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
@@ -16052,1242 +13826,73 @@
         "@aws-sdk/middleware-host-header": "3.208.0",
         "@aws-sdk/middleware-logger": "3.208.0",
         "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
         "@aws-sdk/middleware-serde": "3.208.0",
         "@aws-sdk/middleware-signing": "3.208.0",
         "@aws-sdk/middleware-stack": "3.208.0",
         "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/node-http-handler": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/url-parser": "3.208.0",
         "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/abort-controller": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
-          "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.208.0.tgz",
-          "integrity": "sha512-3e6kEFtuxqZVv1cLGbXFAytTPzR1GpctKITEtJR0MFy3pzj8ttbybrHe0F8z2AqAtDhna1i3u1WVZa+LK3gE9Q==",
-          "dev": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.208.0",
-            "@aws-sdk/fetch-http-handler": "3.208.0",
-            "@aws-sdk/hash-node": "3.208.0",
-            "@aws-sdk/invalid-dependency": "3.208.0",
-            "@aws-sdk/middleware-content-length": "3.208.0",
-            "@aws-sdk/middleware-endpoint": "3.208.0",
-            "@aws-sdk/middleware-host-header": "3.208.0",
-            "@aws-sdk/middleware-logger": "3.208.0",
-            "@aws-sdk/middleware-recursion-detection": "3.208.0",
-            "@aws-sdk/middleware-retry": "3.208.0",
-            "@aws-sdk/middleware-serde": "3.208.0",
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/middleware-user-agent": "3.208.0",
-            "@aws-sdk/node-config-provider": "3.208.0",
-            "@aws-sdk/node-http-handler": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/smithy-client": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-base64-browser": "3.208.0",
-            "@aws-sdk/util-base64-node": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-            "@aws-sdk/util-defaults-mode-node": "3.208.0",
-            "@aws-sdk/util-endpoints": "3.208.0",
-            "@aws-sdk/util-user-agent-browser": "3.208.0",
-            "@aws-sdk/util-user-agent-node": "3.208.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.208.0.tgz",
-          "integrity": "sha512-xmPxI/vW0YVm2YhmIfdTQYY8b8dvzP0ordgooDlzAZVj5KnpZLVzQUxin5EqVcZYFJp6qEkVwmFK03QLy9fYOw==",
-          "dev": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.208.0",
-            "@aws-sdk/credential-provider-node": "3.208.0",
-            "@aws-sdk/fetch-http-handler": "3.208.0",
-            "@aws-sdk/hash-node": "3.208.0",
-            "@aws-sdk/invalid-dependency": "3.208.0",
-            "@aws-sdk/middleware-content-length": "3.208.0",
-            "@aws-sdk/middleware-endpoint": "3.208.0",
-            "@aws-sdk/middleware-host-header": "3.208.0",
-            "@aws-sdk/middleware-logger": "3.208.0",
-            "@aws-sdk/middleware-recursion-detection": "3.208.0",
-            "@aws-sdk/middleware-retry": "3.208.0",
-            "@aws-sdk/middleware-sdk-sts": "3.208.0",
-            "@aws-sdk/middleware-serde": "3.208.0",
-            "@aws-sdk/middleware-signing": "3.208.0",
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/middleware-user-agent": "3.208.0",
-            "@aws-sdk/node-config-provider": "3.208.0",
-            "@aws-sdk/node-http-handler": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/smithy-client": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-base64-browser": "3.208.0",
-            "@aws-sdk/util-base64-node": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-            "@aws-sdk/util-defaults-mode-node": "3.208.0",
-            "@aws-sdk/util-endpoints": "3.208.0",
-            "@aws-sdk/util-user-agent-browser": "3.208.0",
-            "@aws-sdk/util-user-agent-node": "3.208.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "fast-xml-parser": "4.0.11",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/config-resolver": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.208.0.tgz",
-          "integrity": "sha512-eLwI7rjk3AJj/S8PqRcUi9iBD+cTm1Nzu1CmYyeiwU6YbJLe5/2CrhW1wjkOGleE+aD967U1TWiB18tsx6fj+w==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/signature-v4": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz",
-          "integrity": "sha512-FB+KUSpZc03wVTXxGnMmgtaP0sJOv0D7oyogHb7wcf5b7RjjwqoaeUcJHTdKRZaW6e1foLk3/L9uebxiWefDbQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-imds": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.208.0.tgz",
-          "integrity": "sha512-z4Bk42FQefBzS1SZ6/4gsAFE7tQhEoDmSUrFVSDu/9WwvGpFMnFfHLTBhivlcAHjc/eQ/hiWYLnQ8vahqhHl8w==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.208.0.tgz",
-          "integrity": "sha512-AhsUj4046wMnxrPunNVEuddOIb//KsaicRqucw1Pb/UqszDRO4hYWkw7pL10MPIqjHBwuXYZ3vjDZrIhIWMn7A==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.208.0",
-            "@aws-sdk/credential-provider-imds": "3.208.0",
-            "@aws-sdk/credential-provider-sso": "3.208.0",
-            "@aws-sdk/credential-provider-web-identity": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.208.0.tgz",
-          "integrity": "sha512-KYoxlpDzvhw6v0ae0TgIGPP52HJUHQGI3yImhAZZTz0Nh5B0zd2stip+p36sCYRW6V+TJ5mo5minwqDmYe8oXg==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.208.0",
-            "@aws-sdk/credential-provider-imds": "3.208.0",
-            "@aws-sdk/credential-provider-ini": "3.208.0",
-            "@aws-sdk/credential-provider-process": "3.208.0",
-            "@aws-sdk/credential-provider-sso": "3.208.0",
-            "@aws-sdk/credential-provider-web-identity": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.208.0.tgz",
-          "integrity": "sha512-ExvFSJB/pVV+/BXIvFR9dgoGxWWnF6uqIw1hfpWCh28UDwsOQdbfUKblMovUfPDBUw67Laqy3mtiY37Jyo/EUQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.208.0.tgz",
-          "integrity": "sha512-GVUBmSG8eO4oXy5XpslAgVUBimEVBYmyCdwrwED79ey/7NWfkIVt46VZQapWyAJsarKW+VFpx7BYnam9YBR6hA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/client-sso": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.208.0.tgz",
-          "integrity": "sha512-7wtrdEr8uvDr5t0stimrXGsW4G+TQyluZ9OucCCY0HXgNihmnk1BIu+COuOSxRtFXHwCh4rIPaVE1ABG2Mq24g==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/fetch-http-handler": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
-          "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/querystring-builder": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/hash-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz",
-          "integrity": "sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/invalid-dependency": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz",
-          "integrity": "sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-content-length": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz",
-          "integrity": "sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz",
-          "integrity": "sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz",
-          "integrity": "sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-retry": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.208.0.tgz",
-          "integrity": "sha512-JAcN2e3PKWGcNX7run/jP6xJ7w2m15a2CpVrfMtka9p/I/3qnqB86jGUs/3Iv04FEqgXq7KTHbFBg8CndsaHEw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/service-error-classification": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1",
-            "uuid": "^8.3.2"
-          }
-        },
-        "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.208.0.tgz",
-          "integrity": "sha512-lFVodZHYLF7puXgNZ1m5ycKbyCPp79nqI+pkRXl066ZtZWzCW8+JKCaLjF3jfXlnvg6foPDJdxUvt0VU5EddGg==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/middleware-signing": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/signature-v4": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-serde": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
-          "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-signing": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.208.0.tgz",
-          "integrity": "sha512-cMSWhg8xOrxZw04EYKEQQQ7RT+03rigS4KS3Uy6x/M+jFyoM+sRiY/7376sJCwlpvKH2xJIVpwPbKk/uz4j4DA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/signature-v4": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-stack": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz",
-          "integrity": "sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz",
-          "integrity": "sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-config-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.208.0.tgz",
-          "integrity": "sha512-htjs1cDXYXEMwZ1q2vb7wfG3bOW4weWWkKcfT7vqzZKfTXoMH2mPpJIXnPE1PxXerOLXHGUU8qqhfl6LxjlnfQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-http-handler": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
-          "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/abort-controller": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/querystring-builder": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/property-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-          "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-          "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-builder": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-          "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-          "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/service-error-classification": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz",
-          "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw==",
-          "dev": true
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.208.0.tgz",
-          "integrity": "sha512-ZDmwOLNiBKfvtN1M2eG2bItw0+4hKDU/XKqB+yVI9Uo29o4XwtQ4Br7HixTlPYJAavmM1cCch8PVvnwngYAKPA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-          "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.208.0.tgz",
-          "integrity": "sha512-4SGPAs7ZtG9AUYknJNkZTs+ww1cpdcPth5te+R/dN4anUbqtL2qvmbdZJ+8rzdAZKndXu0huKE1OZrR3COLciw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-          "dev": true
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-          "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-base64-browser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.208.0.tgz",
-          "integrity": "sha512-nR6S6aZqlr//Sy3+2J7G2mn5XG1ELBBTswvbp6kCo5BK9v/kESuzsHC5b6f3xzl/TY4JSG8Aj+h7x+kZHfKwwg==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-base64-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.208.0.tgz",
-          "integrity": "sha512-tCkSexa90loq8yU+BKAX5WIVQGq8IM/DdFhFphQd1azgOIBYxafA/aVw9mDY+to0mq4QRHiUwmUsmzLWEFSDJg==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-body-length-browser": {
-          "version": "3.188.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-body-length-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-config-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz",
-          "integrity": "sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.208.0.tgz",
-          "integrity": "sha512-T7V3TTc+NdcHgITo8yMUDs/qR0wfPjURUrCixHPtqYkqvhoF6YrHUAoCbOcz7SG/Tsm2GgSKAHB4ip9D2QLg4g==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-utf8-browser": {
-          "version": "3.188.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-utf8-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-          "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "fast-xml-parser": {
-          "version": "4.0.11",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-          "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-          "dev": true,
-          "requires": {
-            "strnum": "^1.0.5"
-          }
-        }
       }
     },
     "@aws-sdk/client-dynamodb": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.208.0.tgz",
-      "integrity": "sha512-+guT9SC1n/eJ5cdrruCXs4q8q/eoeqSF2siGDyE7+0QMaUbkwWBWJkv6jjxHSVvfLkLkQIn2foJ4gaRj23qXRQ==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.211.0.tgz",
+      "integrity": "sha512-SoinZ+k1TgY/99dUZ2S+FH+sXG3+BaFaSd98if0dygTqIftq9ctaRbDQFss64hdrqu6Qpuvak4XhqaRMaQOr2A==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.208.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-node": "3.208.0",
+        "@aws-sdk/client-sts": "3.211.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.211.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
         "@aws-sdk/middleware-content-length": "3.208.0",
         "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.208.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.209.0",
         "@aws-sdk/middleware-host-header": "3.208.0",
         "@aws-sdk/middleware-logger": "3.208.0",
         "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
         "@aws-sdk/middleware-serde": "3.208.0",
         "@aws-sdk/middleware-signing": "3.208.0",
         "@aws-sdk/middleware-stack": "3.208.0",
         "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/node-http-handler": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/url-parser": "3.208.0",
         "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "@aws-sdk/util-waiter": "3.208.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "@aws-sdk/abort-controller": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
-          "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.208.0.tgz",
-          "integrity": "sha512-3e6kEFtuxqZVv1cLGbXFAytTPzR1GpctKITEtJR0MFy3pzj8ttbybrHe0F8z2AqAtDhna1i3u1WVZa+LK3gE9Q==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.208.0",
-            "@aws-sdk/fetch-http-handler": "3.208.0",
-            "@aws-sdk/hash-node": "3.208.0",
-            "@aws-sdk/invalid-dependency": "3.208.0",
-            "@aws-sdk/middleware-content-length": "3.208.0",
-            "@aws-sdk/middleware-endpoint": "3.208.0",
-            "@aws-sdk/middleware-host-header": "3.208.0",
-            "@aws-sdk/middleware-logger": "3.208.0",
-            "@aws-sdk/middleware-recursion-detection": "3.208.0",
-            "@aws-sdk/middleware-retry": "3.208.0",
-            "@aws-sdk/middleware-serde": "3.208.0",
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/middleware-user-agent": "3.208.0",
-            "@aws-sdk/node-config-provider": "3.208.0",
-            "@aws-sdk/node-http-handler": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/smithy-client": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-base64-browser": "3.208.0",
-            "@aws-sdk/util-base64-node": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-            "@aws-sdk/util-defaults-mode-node": "3.208.0",
-            "@aws-sdk/util-endpoints": "3.208.0",
-            "@aws-sdk/util-user-agent-browser": "3.208.0",
-            "@aws-sdk/util-user-agent-node": "3.208.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.208.0.tgz",
-          "integrity": "sha512-xmPxI/vW0YVm2YhmIfdTQYY8b8dvzP0ordgooDlzAZVj5KnpZLVzQUxin5EqVcZYFJp6qEkVwmFK03QLy9fYOw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.208.0",
-            "@aws-sdk/credential-provider-node": "3.208.0",
-            "@aws-sdk/fetch-http-handler": "3.208.0",
-            "@aws-sdk/hash-node": "3.208.0",
-            "@aws-sdk/invalid-dependency": "3.208.0",
-            "@aws-sdk/middleware-content-length": "3.208.0",
-            "@aws-sdk/middleware-endpoint": "3.208.0",
-            "@aws-sdk/middleware-host-header": "3.208.0",
-            "@aws-sdk/middleware-logger": "3.208.0",
-            "@aws-sdk/middleware-recursion-detection": "3.208.0",
-            "@aws-sdk/middleware-retry": "3.208.0",
-            "@aws-sdk/middleware-sdk-sts": "3.208.0",
-            "@aws-sdk/middleware-serde": "3.208.0",
-            "@aws-sdk/middleware-signing": "3.208.0",
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/middleware-user-agent": "3.208.0",
-            "@aws-sdk/node-config-provider": "3.208.0",
-            "@aws-sdk/node-http-handler": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/smithy-client": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-base64-browser": "3.208.0",
-            "@aws-sdk/util-base64-node": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-            "@aws-sdk/util-defaults-mode-node": "3.208.0",
-            "@aws-sdk/util-endpoints": "3.208.0",
-            "@aws-sdk/util-user-agent-browser": "3.208.0",
-            "@aws-sdk/util-user-agent-node": "3.208.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "fast-xml-parser": "4.0.11",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/config-resolver": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.208.0.tgz",
-          "integrity": "sha512-eLwI7rjk3AJj/S8PqRcUi9iBD+cTm1Nzu1CmYyeiwU6YbJLe5/2CrhW1wjkOGleE+aD967U1TWiB18tsx6fj+w==",
-          "requires": {
-            "@aws-sdk/signature-v4": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz",
-          "integrity": "sha512-FB+KUSpZc03wVTXxGnMmgtaP0sJOv0D7oyogHb7wcf5b7RjjwqoaeUcJHTdKRZaW6e1foLk3/L9uebxiWefDbQ==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-imds": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.208.0.tgz",
-          "integrity": "sha512-z4Bk42FQefBzS1SZ6/4gsAFE7tQhEoDmSUrFVSDu/9WwvGpFMnFfHLTBhivlcAHjc/eQ/hiWYLnQ8vahqhHl8w==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.208.0.tgz",
-          "integrity": "sha512-AhsUj4046wMnxrPunNVEuddOIb//KsaicRqucw1Pb/UqszDRO4hYWkw7pL10MPIqjHBwuXYZ3vjDZrIhIWMn7A==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.208.0",
-            "@aws-sdk/credential-provider-imds": "3.208.0",
-            "@aws-sdk/credential-provider-sso": "3.208.0",
-            "@aws-sdk/credential-provider-web-identity": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.208.0.tgz",
-          "integrity": "sha512-KYoxlpDzvhw6v0ae0TgIGPP52HJUHQGI3yImhAZZTz0Nh5B0zd2stip+p36sCYRW6V+TJ5mo5minwqDmYe8oXg==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.208.0",
-            "@aws-sdk/credential-provider-imds": "3.208.0",
-            "@aws-sdk/credential-provider-ini": "3.208.0",
-            "@aws-sdk/credential-provider-process": "3.208.0",
-            "@aws-sdk/credential-provider-sso": "3.208.0",
-            "@aws-sdk/credential-provider-web-identity": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.208.0.tgz",
-          "integrity": "sha512-ExvFSJB/pVV+/BXIvFR9dgoGxWWnF6uqIw1hfpWCh28UDwsOQdbfUKblMovUfPDBUw67Laqy3mtiY37Jyo/EUQ==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.208.0.tgz",
-          "integrity": "sha512-GVUBmSG8eO4oXy5XpslAgVUBimEVBYmyCdwrwED79ey/7NWfkIVt46VZQapWyAJsarKW+VFpx7BYnam9YBR6hA==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.208.0.tgz",
-          "integrity": "sha512-7wtrdEr8uvDr5t0stimrXGsW4G+TQyluZ9OucCCY0HXgNihmnk1BIu+COuOSxRtFXHwCh4rIPaVE1ABG2Mq24g==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/fetch-http-handler": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
-          "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/querystring-builder": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/hash-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz",
-          "integrity": "sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/invalid-dependency": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz",
-          "integrity": "sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-content-length": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz",
-          "integrity": "sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz",
-          "integrity": "sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz",
-          "integrity": "sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-retry": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.208.0.tgz",
-          "integrity": "sha512-JAcN2e3PKWGcNX7run/jP6xJ7w2m15a2CpVrfMtka9p/I/3qnqB86jGUs/3Iv04FEqgXq7KTHbFBg8CndsaHEw==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/service-error-classification": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1",
-            "uuid": "^8.3.2"
-          }
-        },
-        "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.208.0.tgz",
-          "integrity": "sha512-lFVodZHYLF7puXgNZ1m5ycKbyCPp79nqI+pkRXl066ZtZWzCW8+JKCaLjF3jfXlnvg6foPDJdxUvt0VU5EddGg==",
-          "requires": {
-            "@aws-sdk/middleware-signing": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/signature-v4": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-serde": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
-          "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-signing": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.208.0.tgz",
-          "integrity": "sha512-cMSWhg8xOrxZw04EYKEQQQ7RT+03rigS4KS3Uy6x/M+jFyoM+sRiY/7376sJCwlpvKH2xJIVpwPbKk/uz4j4DA==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/signature-v4": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-stack": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz",
-          "integrity": "sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz",
-          "integrity": "sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-config-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.208.0.tgz",
-          "integrity": "sha512-htjs1cDXYXEMwZ1q2vb7wfG3bOW4weWWkKcfT7vqzZKfTXoMH2mPpJIXnPE1PxXerOLXHGUU8qqhfl6LxjlnfQ==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-http-handler": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
-          "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
-          "requires": {
-            "@aws-sdk/abort-controller": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/querystring-builder": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/property-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-          "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-          "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-builder": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-          "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-          "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/service-error-classification": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz",
-          "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw=="
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.208.0.tgz",
-          "integrity": "sha512-ZDmwOLNiBKfvtN1M2eG2bItw0+4hKDU/XKqB+yVI9Uo29o4XwtQ4Br7HixTlPYJAavmM1cCch8PVvnwngYAKPA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-          "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.208.0.tgz",
-          "integrity": "sha512-4SGPAs7ZtG9AUYknJNkZTs+ww1cpdcPth5te+R/dN4anUbqtL2qvmbdZJ+8rzdAZKndXu0huKE1OZrR3COLciw==",
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-          "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-base64-browser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.208.0.tgz",
-          "integrity": "sha512-nR6S6aZqlr//Sy3+2J7G2mn5XG1ELBBTswvbp6kCo5BK9v/kESuzsHC5b6f3xzl/TY4JSG8Aj+h7x+kZHfKwwg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-base64-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.208.0.tgz",
-          "integrity": "sha512-tCkSexa90loq8yU+BKAX5WIVQGq8IM/DdFhFphQd1azgOIBYxafA/aVw9mDY+to0mq4QRHiUwmUsmzLWEFSDJg==",
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-body-length-browser": {
-          "version": "3.188.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-body-length-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-config-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz",
-          "integrity": "sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.208.0.tgz",
-          "integrity": "sha512-T7V3TTc+NdcHgITo8yMUDs/qR0wfPjURUrCixHPtqYkqvhoF6YrHUAoCbOcz7SG/Tsm2GgSKAHB4ip9D2QLg4g==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-utf8-browser": {
-          "version": "3.188.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-utf8-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-          "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-waiter": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.208.0.tgz",
-          "integrity": "sha512-DEMVnoZXLUXeakBDMe9IhZ8VQCVf/5cMlNtE+4EpSVvH8CEE0Qfc0nDjrTYEkLpAIZWRL3tpHx61MMKvgCirXA==",
-          "requires": {
-            "@aws-sdk/abort-controller": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "fast-xml-parser": {
-          "version": "4.0.11",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-          "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-          "requires": {
-            "strnum": "^1.0.5"
-          }
-        }
       }
     },
     "@aws-sdk/client-lambda": {
@@ -17327,19 +13932,550 @@
         "@aws-sdk/util-utf8-node": "3.37.0",
         "@aws-sdk/util-waiter": "3.40.0",
         "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.40.0.tgz",
+          "integrity": "sha512-S7LzLvNuwuf0q7r4q7zqGzxd/W2xYsn8cpZ90MMb3ObolhbkLySrikUJujmXae8k+2/KFCOr+FVC0YLrATSUgQ==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.41.0.tgz",
+          "integrity": "sha512-xDvcy7wv3KdHhOpl5fZN+Ydw+dHBmsCZwMFI1ZdJVCSGO+ZKgl5KVWi1LCif6vjZP1pUuGl44oDOZz1ACqOzTg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.40.0",
+            "@aws-sdk/fetch-http-handler": "3.40.0",
+            "@aws-sdk/hash-node": "3.40.0",
+            "@aws-sdk/invalid-dependency": "3.40.0",
+            "@aws-sdk/middleware-content-length": "3.40.0",
+            "@aws-sdk/middleware-host-header": "3.40.0",
+            "@aws-sdk/middleware-logger": "3.40.0",
+            "@aws-sdk/middleware-retry": "3.40.0",
+            "@aws-sdk/middleware-serde": "3.40.0",
+            "@aws-sdk/middleware-stack": "3.40.0",
+            "@aws-sdk/middleware-user-agent": "3.40.0",
+            "@aws-sdk/node-config-provider": "3.40.0",
+            "@aws-sdk/node-http-handler": "3.40.0",
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/smithy-client": "3.41.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/url-parser": "3.40.0",
+            "@aws-sdk/util-base64-browser": "3.37.0",
+            "@aws-sdk/util-base64-node": "3.37.0",
+            "@aws-sdk/util-body-length-browser": "3.37.0",
+            "@aws-sdk/util-body-length-node": "3.37.0",
+            "@aws-sdk/util-user-agent-browser": "3.40.0",
+            "@aws-sdk/util-user-agent-node": "3.40.0",
+            "@aws-sdk/util-utf8-browser": "3.37.0",
+            "@aws-sdk/util-utf8-node": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.43.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.43.0.tgz",
+          "integrity": "sha512-4CKYimjhIEixVtJH0Y8FR5FXc7zIepZtfScy8QHgH+DERXm/YL5cuUbkJiL6ZRTpek0vztVvE+mNSQU0z1eXag==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.40.0",
+            "@aws-sdk/credential-provider-node": "3.41.0",
+            "@aws-sdk/fetch-http-handler": "3.40.0",
+            "@aws-sdk/hash-node": "3.40.0",
+            "@aws-sdk/invalid-dependency": "3.40.0",
+            "@aws-sdk/middleware-content-length": "3.40.0",
+            "@aws-sdk/middleware-host-header": "3.40.0",
+            "@aws-sdk/middleware-logger": "3.40.0",
+            "@aws-sdk/middleware-retry": "3.40.0",
+            "@aws-sdk/middleware-sdk-sts": "3.40.0",
+            "@aws-sdk/middleware-serde": "3.40.0",
+            "@aws-sdk/middleware-signing": "3.40.0",
+            "@aws-sdk/middleware-stack": "3.40.0",
+            "@aws-sdk/middleware-user-agent": "3.40.0",
+            "@aws-sdk/node-config-provider": "3.40.0",
+            "@aws-sdk/node-http-handler": "3.40.0",
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/smithy-client": "3.41.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/url-parser": "3.40.0",
+            "@aws-sdk/util-base64-browser": "3.37.0",
+            "@aws-sdk/util-base64-node": "3.37.0",
+            "@aws-sdk/util-body-length-browser": "3.37.0",
+            "@aws-sdk/util-body-length-node": "3.37.0",
+            "@aws-sdk/util-user-agent-browser": "3.40.0",
+            "@aws-sdk/util-user-agent-node": "3.40.0",
+            "@aws-sdk/util-utf8-browser": "3.37.0",
+            "@aws-sdk/util-utf8-node": "3.37.0",
+            "entities": "2.2.0",
+            "fast-xml-parser": "3.19.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.40.0.tgz",
+          "integrity": "sha512-QYy6J2k31QL6J74hPBfptnLW1kQYdN+xjwH4UQ1mv7EUhRoJN9ZY2soStJowFy4at6IIOOVWbyG5dyqvrbEovg==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-config-provider": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.40.0.tgz",
+          "integrity": "sha512-qHZdf2vxhzZkSygjw2I4SEYFL2dMZxxYvO4QlkqQouKY81OVxs/j69oiNCjPasQzGz5jaZZKI8xEAIfkSyr1lg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.40.0.tgz",
+          "integrity": "sha512-Ty/wVa+BQrCFrP06AGl5S1CeLifDt68YrlYXUnkRn603SX4DvxBgVO7XFeDH58G8ziDCiqxfmVl4yjbncPPeSw==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.40.0",
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/url-parser": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.41.0.tgz",
+          "integrity": "sha512-98CGEHg7Tb6HxK5ZIdbAcijvD3IpLe0ddse1xMe/Ilhjz770FS/L2UNprOP6PZTqrSfBffiMrvfThUSuUaTlIQ==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.40.0",
+            "@aws-sdk/credential-provider-imds": "3.40.0",
+            "@aws-sdk/credential-provider-sso": "3.41.0",
+            "@aws-sdk/credential-provider-web-identity": "3.41.0",
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/shared-ini-file-loader": "3.37.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-credentials": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.41.0.tgz",
+          "integrity": "sha512-5FW6+wNJgyDCsbAd+mLm/1DBTDkyIYOMVzcxbr6Vi3pM4UrMFdeLdAP62edYW8usg78Xg+c6vaAoEv/M3zkS0Q==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.40.0",
+            "@aws-sdk/credential-provider-imds": "3.40.0",
+            "@aws-sdk/credential-provider-ini": "3.41.0",
+            "@aws-sdk/credential-provider-process": "3.40.0",
+            "@aws-sdk/credential-provider-sso": "3.41.0",
+            "@aws-sdk/credential-provider-web-identity": "3.41.0",
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/shared-ini-file-loader": "3.37.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-credentials": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.40.0.tgz",
+          "integrity": "sha512-qsaNCDesW2GasDbzpeOA371gxugi05JWxt3EKonLbUfkGKBK7kmmL6EgLIxZuNm2/Ve4RS07PKp8yBGm4xIx9w==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/shared-ini-file-loader": "3.37.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-credentials": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.41.0.tgz",
+          "integrity": "sha512-9s7SWu3RVIQ/MTcBCt35EMzxNQm3avivrbpSOKfJwxR5L+oNKPsV+gSqMlkNZGwOVJyUicIsZGcq/4ON6CjrOg==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.41.0",
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/shared-ini-file-loader": "3.37.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-credentials": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.41.0.tgz",
+          "integrity": "sha512-VqvVoEh9C8xTXl4stKyJC5IKQhS8g1Gi5k6B9HPHLIxFRRfKxkE73DT4pMN6npnus7o0yi0MTFGQFQGYSrFO2g==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.40.0.tgz",
+          "integrity": "sha512-w1HiZromoU+/bbEo89uO81l6UO/M+c2uOMnXntZqe6t3ZHUUUo3AbvhKh0QGVFqRQa+Oi0+95KqWmTHa72/9Iw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/querystring-builder": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-base64-browser": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.40.0.tgz",
+          "integrity": "sha512-yOXXK85DdGDktdnQtXgMdaVKii4wtMjEhJ1mrvx2A9nMFNaPhxvERkVVIUKSWlJRa9ZujOw5jWOx8d2R51/Kjg==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-buffer-from": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.40.0.tgz",
+          "integrity": "sha512-axIWtDwCBDDqEgAJipX1FB1ZNpWYXquVwKDMo+7G+ftPBZ4FEq4M1ELhXJL3hhNJ9ZmCQzv+4F6Wnt8dwuzUaQ==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.37.0.tgz",
+          "integrity": "sha512-XLjA/a6AuGnCvcJZLsMTy2jxF2upgGhqCCkoIJgLlzzXHSihur13KcmPvW/zcaGnCRj0SvKWXiJHl4vDlW75VQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.40.0.tgz",
+          "integrity": "sha512-sybAJb8v7I/vvL08R3+TI/XDAg9gybQTZ2treC24Ap4+jAOz4QBTHJPMKaUlEeFlMUcq4rj6/u2897ebYH6opw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.40.0.tgz",
+          "integrity": "sha512-/wocR7JFOLM7/+BQM1DgAd6KCFYcdxYu1P7AhI451GlVNuYa5f89zh7p0gt3SRC6monI5lXgpL7RudhDm8fTrA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.40.0.tgz",
+          "integrity": "sha512-19kx0Xg5ymVRKoupmhdmfTBkROcv3DZj508agpyG2YAo0abOObMlIP4Jltg0VD4PhNjGzNh0jFGJnvhjdwv4/A==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.40.0.tgz",
+          "integrity": "sha512-SMUJrukugLL7YJE5X8B2ToukxMWMPwnf7jAFr84ptycCe8bdWv8x8klQ3EtVWpyqochtNlbTi6J/tTQBniUX7A==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/service-error-classification": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.40.0.tgz",
+          "integrity": "sha512-TcrbCvj1PkabFZiNczT3yePZtuEm2fAIw1OVnQyLcF2KW+p62Hv5YkK4MPOfx3LA/0lzjOUO1RNl2x7gzV443Q==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.40.0",
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/signature-v4": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.40.0.tgz",
+          "integrity": "sha512-uOWfZjlAoBy6xPqp0d4ka83WNNbEVCWn9WwfqBUXThyoTdTooYSpXe5y2YzN0BJa8b+tEZTyWpgamnBpFLp47g==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.40.0.tgz",
+          "integrity": "sha512-RqK5nPbfma0qInMvjtpVkDYY/KkFS6EKlOv3DWTdxbXJ4YuOxgKiuUromhmBUoyjFag0JO7LUWod07H+/DawoA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/signature-v4": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.40.0.tgz",
+          "integrity": "sha512-hby9HvESUYJxpdALX+6Dn2LPmS5jtMVurGB/+j3MWOvIcDYB4bcSXgVRvXzYnTKwbSupIdbX9zOE2ZAx2SJpUQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.40.0.tgz",
+          "integrity": "sha512-dzC2fxWnanetFJ1oYgil8df3N36bR1yc/OCOpbdfQNiUk1FrXiCXqH5rHNO8zCvnwJAj8GHFwpFGd9a2Qube2w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.40.0.tgz",
+          "integrity": "sha512-AmokjgUDECG8osoMfdRsPNweqI+L1pn4bYGk5iTLmzbBi0o4ot0U1FdX8Rf0qJZZwS4t1TXc3s8/PDVknmPxKg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/shared-ini-file-loader": "3.37.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.40.0.tgz",
+          "integrity": "sha512-qjda6IbxDhbYr8NHmrMurKkbjgLUkfTMVgagDErDK24Nm3Dn5VaO6J4n6c0Q4OLHlmFaRcUfZSTrOo5DAubqCw==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.40.0",
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/querystring-builder": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.40.0.tgz",
+          "integrity": "sha512-Mx4lkShjsYRwW9ujHA1pcnuubrWQ4kF5/DXWNfUiXuSIO/0Lojp1qTLheyBm4vzkJIlx5umyP6NvRAUkEHSN4Q==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.40.0.tgz",
+          "integrity": "sha512-f4ea7/HZkjpvGBrnRIuzc/bhrExWrgDv7eulj4htPukZGHdTqSJD3Jk8lEXWvFuX2vUKQDGhEhCDsqup7YWJQQ==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.40.0.tgz",
+          "integrity": "sha512-gO24oipnNaxJRBXB7lhLfa96vIMOd8gtMBqJTjelTjS2e1ZP1YY12CNKKTWwafSk8Ge021erZAG/YTOaXGpv+g==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-uri-escape": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.40.0.tgz",
+          "integrity": "sha512-XZIyaKQIiZAM6zelCBcsLHhVDOLafi7XIOd3jy6SymGN8ajj3HqUJ/vdQ5G6ISTk18OrqgqcCOI9oNzv+nrBcA==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.40.0.tgz",
+          "integrity": "sha512-c8btKmkvjXczWudXubGdbO3JgmjySBUVC/gCrZDNfwNGsG8RYJJQYYcnmt1gWjelUZsgMDl/2PIzxTlxVF91rA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.37.0.tgz",
+          "integrity": "sha512-+vRBSlfa48R9KL7DpQt3dsu5/+5atjRgoCISblWo3SLpjrx41pKcjKneo7a1u0aP1Xc2oG2TfIyqTWZuOXsmEQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.40.0.tgz",
+          "integrity": "sha512-Q1GNZJRCS3W2qsRtDsX/b6EOSfMXfr6TW46N3LnLTGYZ3KAN2SOSJ1DsW59AuGpEZyRmOhJ9L/Q5U403+bZMXQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.37.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-hex-encoding": "3.37.0",
+            "@aws-sdk/util-uri-escape": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.41.0.tgz",
+          "integrity": "sha512-ldhS0Pf3v6yHCd//kk5DvKcdyeUkKEwxNDRanAp+ekTW68J3XcYgKaPC9sNDhVTDH1zrywTvtEz5zWHEvXjQow==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
+          "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.40.0.tgz",
+          "integrity": "sha512-HwNV+HX7bHgLk5FzTOgdXANsC0SeVz5PMC4Nh+TLz2IoeQnrw4H8dsA4YNonncjern5oC5veKRjQeOoCL5SlSQ==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.37.0.tgz",
+          "integrity": "sha512-tClmH1uYelqWT43xxmnOsVFbCQJiIwizp6y4E109G2LIof07inxrO0L8nbwBpjhugVplx6NZr9IaqTFqbdM1gA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.37.0.tgz",
+          "integrity": "sha512-aY3mXdbEajruRi9CHgq/heM89R+Gectj/Xrs1naewmamaN8NJrvjDm3s+cw//lqqSOW903LYHXDgm7wvCzUnFA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.37.0.tgz",
+          "integrity": "sha512-aa3SBwjLwImuJoE4+hxDIWQ9REz3UFb3p7KFPe9qopdXb/yB12RTcbrXVb4whUux4i4mO6KRij0ZNjFZrjrKPg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.40.0.tgz",
+          "integrity": "sha512-NjZGrA4mqhpr6gkVCAUweurP0Z9d3vFyXJCtulC0BFbpKAnKCf/crSK56NwUaNhAEMCkSuBvjRFzkbfT+HO8bA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.37.0.tgz",
+          "integrity": "sha512-tn5UpfaeM+rZWqynoNqB8lwtcAXil5YYO3HLGH9himpWAdft/2Z7LK6bsYDpctaAI1WHgMDcL0bw3Id04ZUbhA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.37.0.tgz",
+          "integrity": "sha512-8pKf4YJTELP5lm/CEgYw2atyJBB1RWWqFa0sZx6YJmTlOtLF5G6raUdAi4iDa2hldGt2B6IAdIIyuusT8zeU8Q==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.40.0.tgz",
+          "integrity": "sha512-C69sTI26bV2EprTv3DTXu9XP7kD9Wu4YVPBzqztOYArd2GDYw3w+jS8SEg3XRbjAKY/mOPZ2Thw4StjpZlWZiA==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.40.0.tgz",
+          "integrity": "sha512-cjIzd0hRZFTTh7iLJD6Bciu++Em1iaM1clyG02xRl0JD5DEtDSR1zO02uu+AeM7GSLGOxIvwOkK2j8ySPAOmBA==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.37.0.tgz",
+          "integrity": "sha512-tuiOxzfqet1kKGYzlgpMGfhr64AHJnYsFx2jZiH/O6Yq8XQg43ryjQlbJlim/K/XHGNzY0R+nabeJg34q3Ua1g==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.37.0.tgz",
+          "integrity": "sha512-fUAgd7UTCULL36j9/vnXHxVhxvswnq23mYgTCIT8NQ7wHN30q2a89ym1e9DwGeQkJEBOkOcKLn6nsMsN7YQMDQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-waiter": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.40.0.tgz",
+          "integrity": "sha512-jdxwNEZdID49ZvyAnxaeNm5w2moIfMLOwj/q6TxKlxYoXMs16FQWkhyfGue0vEASzchS49ewbyt+KBqpT31Ebg==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "3.19.0",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+          "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+        }
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.209.0.tgz",
-      "integrity": "sha512-FKRsG93bqM4Ra+wOgq8Rbg6z7enR5bvPdckfZE5bNVq0mUGCFxcCfurvpAxp4dAtQgLZRhMXIPc1B3wAB/UnmA==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.211.0.tgz",
+      "integrity": "sha512-Wk7bqhhdMtys/dd97ap0GMfJcGzlYrlWsGzK5uNF+TqvOcpZ4NIk7Ui0+NCtSfrM8CajfQRamwPKs0N/8sFIiQ==",
       "requires": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.209.0",
+        "@aws-sdk/client-sts": "3.211.0",
         "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.211.0",
         "@aws-sdk/eventstream-serde-browser": "3.208.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.208.0",
         "@aws-sdk/eventstream-serde-node": "3.208.0",
@@ -17377,7 +14513,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
         "@aws-sdk/util-stream-browser": "3.208.0",
         "@aws-sdk/util-stream-node": "3.208.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
@@ -17388,582 +14524,6 @@
         "@aws-sdk/xml-builder": "3.201.0",
         "fast-xml-parser": "4.0.11",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/abort-controller": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
-          "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.209.0.tgz",
-          "integrity": "sha512-rh9QktLCOVTbvDzCb0ikSe4Q1I35Wxcx5XZ7k1J+2ze54FOBfCr3vOwcQpo5tpYWEe1Ysbt3gvA8RAqj9oDFdw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.209.0",
-            "@aws-sdk/fetch-http-handler": "3.208.0",
-            "@aws-sdk/hash-node": "3.208.0",
-            "@aws-sdk/invalid-dependency": "3.208.0",
-            "@aws-sdk/middleware-content-length": "3.208.0",
-            "@aws-sdk/middleware-endpoint": "3.208.0",
-            "@aws-sdk/middleware-host-header": "3.208.0",
-            "@aws-sdk/middleware-logger": "3.208.0",
-            "@aws-sdk/middleware-recursion-detection": "3.208.0",
-            "@aws-sdk/middleware-retry": "3.209.0",
-            "@aws-sdk/middleware-serde": "3.208.0",
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/middleware-user-agent": "3.208.0",
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/node-http-handler": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/smithy-client": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-            "@aws-sdk/util-defaults-mode-node": "3.209.0",
-            "@aws-sdk/util-endpoints": "3.209.0",
-            "@aws-sdk/util-user-agent-browser": "3.208.0",
-            "@aws-sdk/util-user-agent-node": "3.209.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.209.0.tgz",
-          "integrity": "sha512-zWlM+9/JbshEgrG79KZlqYusUziKiKqe8vRlvQ9wcuEHNbQnAri4UvObEKik+7YpTBeP3mR+US1T71G0PqJByw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.209.0",
-            "@aws-sdk/credential-provider-node": "3.209.0",
-            "@aws-sdk/fetch-http-handler": "3.208.0",
-            "@aws-sdk/hash-node": "3.208.0",
-            "@aws-sdk/invalid-dependency": "3.208.0",
-            "@aws-sdk/middleware-content-length": "3.208.0",
-            "@aws-sdk/middleware-endpoint": "3.208.0",
-            "@aws-sdk/middleware-host-header": "3.208.0",
-            "@aws-sdk/middleware-logger": "3.208.0",
-            "@aws-sdk/middleware-recursion-detection": "3.208.0",
-            "@aws-sdk/middleware-retry": "3.209.0",
-            "@aws-sdk/middleware-sdk-sts": "3.208.0",
-            "@aws-sdk/middleware-serde": "3.208.0",
-            "@aws-sdk/middleware-signing": "3.208.0",
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/middleware-user-agent": "3.208.0",
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/node-http-handler": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/smithy-client": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-            "@aws-sdk/util-defaults-mode-node": "3.209.0",
-            "@aws-sdk/util-endpoints": "3.209.0",
-            "@aws-sdk/util-user-agent-browser": "3.208.0",
-            "@aws-sdk/util-user-agent-node": "3.209.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "fast-xml-parser": "4.0.11",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/config-resolver": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
-          "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
-          "requires": {
-            "@aws-sdk/signature-v4": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz",
-          "integrity": "sha512-FB+KUSpZc03wVTXxGnMmgtaP0sJOv0D7oyogHb7wcf5b7RjjwqoaeUcJHTdKRZaW6e1foLk3/L9uebxiWefDbQ==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-imds": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
-          "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.209.0.tgz",
-          "integrity": "sha512-aszuzkKIg7V+tCcq8RNpr1dAyECXWvJRAvzlmE5ZBYtjHMIX/qVAqSP4sfLNeI/Qagyj7W0TeVA1XVRjkivjYA==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.208.0",
-            "@aws-sdk/credential-provider-imds": "3.209.0",
-            "@aws-sdk/credential-provider-sso": "3.209.0",
-            "@aws-sdk/credential-provider-web-identity": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.209.0.tgz",
-          "integrity": "sha512-R0kV6B+GxbfdSowf/6eeEAHZC6X7P/IxJ/o/gCuMmAOixge0e6AWVgCvrd0cg0togJHWbmoYSuUyqWPIMxM1Yg==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.208.0",
-            "@aws-sdk/credential-provider-imds": "3.209.0",
-            "@aws-sdk/credential-provider-ini": "3.209.0",
-            "@aws-sdk/credential-provider-process": "3.209.0",
-            "@aws-sdk/credential-provider-sso": "3.209.0",
-            "@aws-sdk/credential-provider-web-identity": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz",
-          "integrity": "sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.209.0.tgz",
-          "integrity": "sha512-SKzUYOn2EFx58+iU1KihGLtBz9s1jolWUQ6HYxOy4AkWnZVGUt9Vb4mIo6wB07nSSUgYRxOSYn21SKvvBzpc2g==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.209.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/token-providers": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.208.0.tgz",
-          "integrity": "sha512-7wtrdEr8uvDr5t0stimrXGsW4G+TQyluZ9OucCCY0HXgNihmnk1BIu+COuOSxRtFXHwCh4rIPaVE1ABG2Mq24g==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/fetch-http-handler": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
-          "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/querystring-builder": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/hash-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz",
-          "integrity": "sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/invalid-dependency": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz",
-          "integrity": "sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-content-length": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz",
-          "integrity": "sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz",
-          "integrity": "sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz",
-          "integrity": "sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-retry": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
-          "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/service-error-classification": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1",
-            "uuid": "^8.3.2"
-          }
-        },
-        "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.208.0.tgz",
-          "integrity": "sha512-lFVodZHYLF7puXgNZ1m5ycKbyCPp79nqI+pkRXl066ZtZWzCW8+JKCaLjF3jfXlnvg6foPDJdxUvt0VU5EddGg==",
-          "requires": {
-            "@aws-sdk/middleware-signing": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/signature-v4": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-serde": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
-          "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-signing": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.208.0.tgz",
-          "integrity": "sha512-cMSWhg8xOrxZw04EYKEQQQ7RT+03rigS4KS3Uy6x/M+jFyoM+sRiY/7376sJCwlpvKH2xJIVpwPbKk/uz4j4DA==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/signature-v4": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-stack": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz",
-          "integrity": "sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz",
-          "integrity": "sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-config-provider": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
-          "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-http-handler": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
-          "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
-          "requires": {
-            "@aws-sdk/abort-controller": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/querystring-builder": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/property-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-          "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-          "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-builder": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-          "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-          "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/service-error-classification": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz",
-          "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw=="
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-          "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-          "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
-          "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-          "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-body-length-browser": {
-          "version": "3.188.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-body-length-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-config-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-browser": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
-          "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-node": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
-          "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
-          "requires": {
-            "@aws-sdk/config-resolver": "3.209.0",
-            "@aws-sdk/credential-provider-imds": "3.209.0",
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
-          "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz",
-          "integrity": "sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
-          "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-utf8-browser": {
-          "version": "3.188.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-utf8-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-          "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-waiter": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.208.0.tgz",
-          "integrity": "sha512-DEMVnoZXLUXeakBDMe9IhZ8VQCVf/5cMlNtE+4EpSVvH8CEE0Qfc0nDjrTYEkLpAIZWRL3tpHx61MMKvgCirXA==",
-          "requires": {
-            "@aws-sdk/abort-controller": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "fast-xml-parser": {
-          "version": "4.0.11",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-          "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-          "requires": {
-            "strnum": "^1.0.5"
-          }
-        }
       }
     },
     "@aws-sdk/client-ssm": {
@@ -18004,47 +14564,543 @@
         "@aws-sdk/util-waiter": "3.40.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.40.0.tgz",
+          "integrity": "sha512-S7LzLvNuwuf0q7r4q7zqGzxd/W2xYsn8cpZ90MMb3ObolhbkLySrikUJujmXae8k+2/KFCOr+FVC0YLrATSUgQ==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.41.0.tgz",
+          "integrity": "sha512-xDvcy7wv3KdHhOpl5fZN+Ydw+dHBmsCZwMFI1ZdJVCSGO+ZKgl5KVWi1LCif6vjZP1pUuGl44oDOZz1ACqOzTg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.40.0",
+            "@aws-sdk/fetch-http-handler": "3.40.0",
+            "@aws-sdk/hash-node": "3.40.0",
+            "@aws-sdk/invalid-dependency": "3.40.0",
+            "@aws-sdk/middleware-content-length": "3.40.0",
+            "@aws-sdk/middleware-host-header": "3.40.0",
+            "@aws-sdk/middleware-logger": "3.40.0",
+            "@aws-sdk/middleware-retry": "3.40.0",
+            "@aws-sdk/middleware-serde": "3.40.0",
+            "@aws-sdk/middleware-stack": "3.40.0",
+            "@aws-sdk/middleware-user-agent": "3.40.0",
+            "@aws-sdk/node-config-provider": "3.40.0",
+            "@aws-sdk/node-http-handler": "3.40.0",
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/smithy-client": "3.41.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/url-parser": "3.40.0",
+            "@aws-sdk/util-base64-browser": "3.37.0",
+            "@aws-sdk/util-base64-node": "3.37.0",
+            "@aws-sdk/util-body-length-browser": "3.37.0",
+            "@aws-sdk/util-body-length-node": "3.37.0",
+            "@aws-sdk/util-user-agent-browser": "3.40.0",
+            "@aws-sdk/util-user-agent-node": "3.40.0",
+            "@aws-sdk/util-utf8-browser": "3.37.0",
+            "@aws-sdk/util-utf8-node": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.43.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.43.0.tgz",
+          "integrity": "sha512-4CKYimjhIEixVtJH0Y8FR5FXc7zIepZtfScy8QHgH+DERXm/YL5cuUbkJiL6ZRTpek0vztVvE+mNSQU0z1eXag==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.40.0",
+            "@aws-sdk/credential-provider-node": "3.41.0",
+            "@aws-sdk/fetch-http-handler": "3.40.0",
+            "@aws-sdk/hash-node": "3.40.0",
+            "@aws-sdk/invalid-dependency": "3.40.0",
+            "@aws-sdk/middleware-content-length": "3.40.0",
+            "@aws-sdk/middleware-host-header": "3.40.0",
+            "@aws-sdk/middleware-logger": "3.40.0",
+            "@aws-sdk/middleware-retry": "3.40.0",
+            "@aws-sdk/middleware-sdk-sts": "3.40.0",
+            "@aws-sdk/middleware-serde": "3.40.0",
+            "@aws-sdk/middleware-signing": "3.40.0",
+            "@aws-sdk/middleware-stack": "3.40.0",
+            "@aws-sdk/middleware-user-agent": "3.40.0",
+            "@aws-sdk/node-config-provider": "3.40.0",
+            "@aws-sdk/node-http-handler": "3.40.0",
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/smithy-client": "3.41.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/url-parser": "3.40.0",
+            "@aws-sdk/util-base64-browser": "3.37.0",
+            "@aws-sdk/util-base64-node": "3.37.0",
+            "@aws-sdk/util-body-length-browser": "3.37.0",
+            "@aws-sdk/util-body-length-node": "3.37.0",
+            "@aws-sdk/util-user-agent-browser": "3.40.0",
+            "@aws-sdk/util-user-agent-node": "3.40.0",
+            "@aws-sdk/util-utf8-browser": "3.37.0",
+            "@aws-sdk/util-utf8-node": "3.37.0",
+            "entities": "2.2.0",
+            "fast-xml-parser": "3.19.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.40.0.tgz",
+          "integrity": "sha512-QYy6J2k31QL6J74hPBfptnLW1kQYdN+xjwH4UQ1mv7EUhRoJN9ZY2soStJowFy4at6IIOOVWbyG5dyqvrbEovg==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-config-provider": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.40.0.tgz",
+          "integrity": "sha512-qHZdf2vxhzZkSygjw2I4SEYFL2dMZxxYvO4QlkqQouKY81OVxs/j69oiNCjPasQzGz5jaZZKI8xEAIfkSyr1lg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.40.0.tgz",
+          "integrity": "sha512-Ty/wVa+BQrCFrP06AGl5S1CeLifDt68YrlYXUnkRn603SX4DvxBgVO7XFeDH58G8ziDCiqxfmVl4yjbncPPeSw==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.40.0",
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/url-parser": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.41.0.tgz",
+          "integrity": "sha512-98CGEHg7Tb6HxK5ZIdbAcijvD3IpLe0ddse1xMe/Ilhjz770FS/L2UNprOP6PZTqrSfBffiMrvfThUSuUaTlIQ==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.40.0",
+            "@aws-sdk/credential-provider-imds": "3.40.0",
+            "@aws-sdk/credential-provider-sso": "3.41.0",
+            "@aws-sdk/credential-provider-web-identity": "3.41.0",
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/shared-ini-file-loader": "3.37.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-credentials": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.41.0.tgz",
+          "integrity": "sha512-5FW6+wNJgyDCsbAd+mLm/1DBTDkyIYOMVzcxbr6Vi3pM4UrMFdeLdAP62edYW8usg78Xg+c6vaAoEv/M3zkS0Q==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.40.0",
+            "@aws-sdk/credential-provider-imds": "3.40.0",
+            "@aws-sdk/credential-provider-ini": "3.41.0",
+            "@aws-sdk/credential-provider-process": "3.40.0",
+            "@aws-sdk/credential-provider-sso": "3.41.0",
+            "@aws-sdk/credential-provider-web-identity": "3.41.0",
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/shared-ini-file-loader": "3.37.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-credentials": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.40.0.tgz",
+          "integrity": "sha512-qsaNCDesW2GasDbzpeOA371gxugi05JWxt3EKonLbUfkGKBK7kmmL6EgLIxZuNm2/Ve4RS07PKp8yBGm4xIx9w==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/shared-ini-file-loader": "3.37.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-credentials": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.41.0.tgz",
+          "integrity": "sha512-9s7SWu3RVIQ/MTcBCt35EMzxNQm3avivrbpSOKfJwxR5L+oNKPsV+gSqMlkNZGwOVJyUicIsZGcq/4ON6CjrOg==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.41.0",
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/shared-ini-file-loader": "3.37.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-credentials": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.41.0.tgz",
+          "integrity": "sha512-VqvVoEh9C8xTXl4stKyJC5IKQhS8g1Gi5k6B9HPHLIxFRRfKxkE73DT4pMN6npnus7o0yi0MTFGQFQGYSrFO2g==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.40.0.tgz",
+          "integrity": "sha512-w1HiZromoU+/bbEo89uO81l6UO/M+c2uOMnXntZqe6t3ZHUUUo3AbvhKh0QGVFqRQa+Oi0+95KqWmTHa72/9Iw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/querystring-builder": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-base64-browser": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.40.0.tgz",
+          "integrity": "sha512-yOXXK85DdGDktdnQtXgMdaVKii4wtMjEhJ1mrvx2A9nMFNaPhxvERkVVIUKSWlJRa9ZujOw5jWOx8d2R51/Kjg==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-buffer-from": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.40.0.tgz",
+          "integrity": "sha512-axIWtDwCBDDqEgAJipX1FB1ZNpWYXquVwKDMo+7G+ftPBZ4FEq4M1ELhXJL3hhNJ9ZmCQzv+4F6Wnt8dwuzUaQ==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.37.0.tgz",
+          "integrity": "sha512-XLjA/a6AuGnCvcJZLsMTy2jxF2upgGhqCCkoIJgLlzzXHSihur13KcmPvW/zcaGnCRj0SvKWXiJHl4vDlW75VQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.40.0.tgz",
+          "integrity": "sha512-sybAJb8v7I/vvL08R3+TI/XDAg9gybQTZ2treC24Ap4+jAOz4QBTHJPMKaUlEeFlMUcq4rj6/u2897ebYH6opw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.40.0.tgz",
+          "integrity": "sha512-/wocR7JFOLM7/+BQM1DgAd6KCFYcdxYu1P7AhI451GlVNuYa5f89zh7p0gt3SRC6monI5lXgpL7RudhDm8fTrA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.40.0.tgz",
+          "integrity": "sha512-19kx0Xg5ymVRKoupmhdmfTBkROcv3DZj508agpyG2YAo0abOObMlIP4Jltg0VD4PhNjGzNh0jFGJnvhjdwv4/A==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.40.0.tgz",
+          "integrity": "sha512-SMUJrukugLL7YJE5X8B2ToukxMWMPwnf7jAFr84ptycCe8bdWv8x8klQ3EtVWpyqochtNlbTi6J/tTQBniUX7A==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/service-error-classification": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.40.0.tgz",
+          "integrity": "sha512-TcrbCvj1PkabFZiNczT3yePZtuEm2fAIw1OVnQyLcF2KW+p62Hv5YkK4MPOfx3LA/0lzjOUO1RNl2x7gzV443Q==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.40.0",
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/signature-v4": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.40.0.tgz",
+          "integrity": "sha512-uOWfZjlAoBy6xPqp0d4ka83WNNbEVCWn9WwfqBUXThyoTdTooYSpXe5y2YzN0BJa8b+tEZTyWpgamnBpFLp47g==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.40.0.tgz",
+          "integrity": "sha512-RqK5nPbfma0qInMvjtpVkDYY/KkFS6EKlOv3DWTdxbXJ4YuOxgKiuUromhmBUoyjFag0JO7LUWod07H+/DawoA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/signature-v4": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.40.0.tgz",
+          "integrity": "sha512-hby9HvESUYJxpdALX+6Dn2LPmS5jtMVurGB/+j3MWOvIcDYB4bcSXgVRvXzYnTKwbSupIdbX9zOE2ZAx2SJpUQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.40.0.tgz",
+          "integrity": "sha512-dzC2fxWnanetFJ1oYgil8df3N36bR1yc/OCOpbdfQNiUk1FrXiCXqH5rHNO8zCvnwJAj8GHFwpFGd9a2Qube2w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.40.0.tgz",
+          "integrity": "sha512-AmokjgUDECG8osoMfdRsPNweqI+L1pn4bYGk5iTLmzbBi0o4ot0U1FdX8Rf0qJZZwS4t1TXc3s8/PDVknmPxKg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.40.0",
+            "@aws-sdk/shared-ini-file-loader": "3.37.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.40.0.tgz",
+          "integrity": "sha512-qjda6IbxDhbYr8NHmrMurKkbjgLUkfTMVgagDErDK24Nm3Dn5VaO6J4n6c0Q4OLHlmFaRcUfZSTrOo5DAubqCw==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.40.0",
+            "@aws-sdk/protocol-http": "3.40.0",
+            "@aws-sdk/querystring-builder": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.40.0.tgz",
+          "integrity": "sha512-Mx4lkShjsYRwW9ujHA1pcnuubrWQ4kF5/DXWNfUiXuSIO/0Lojp1qTLheyBm4vzkJIlx5umyP6NvRAUkEHSN4Q==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.40.0.tgz",
+          "integrity": "sha512-f4ea7/HZkjpvGBrnRIuzc/bhrExWrgDv7eulj4htPukZGHdTqSJD3Jk8lEXWvFuX2vUKQDGhEhCDsqup7YWJQQ==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.40.0.tgz",
+          "integrity": "sha512-gO24oipnNaxJRBXB7lhLfa96vIMOd8gtMBqJTjelTjS2e1ZP1YY12CNKKTWwafSk8Ge021erZAG/YTOaXGpv+g==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-uri-escape": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.40.0.tgz",
+          "integrity": "sha512-XZIyaKQIiZAM6zelCBcsLHhVDOLafi7XIOd3jy6SymGN8ajj3HqUJ/vdQ5G6ISTk18OrqgqcCOI9oNzv+nrBcA==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.40.0.tgz",
+          "integrity": "sha512-c8btKmkvjXczWudXubGdbO3JgmjySBUVC/gCrZDNfwNGsG8RYJJQYYcnmt1gWjelUZsgMDl/2PIzxTlxVF91rA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.37.0.tgz",
+          "integrity": "sha512-+vRBSlfa48R9KL7DpQt3dsu5/+5atjRgoCISblWo3SLpjrx41pKcjKneo7a1u0aP1Xc2oG2TfIyqTWZuOXsmEQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.40.0.tgz",
+          "integrity": "sha512-Q1GNZJRCS3W2qsRtDsX/b6EOSfMXfr6TW46N3LnLTGYZ3KAN2SOSJ1DsW59AuGpEZyRmOhJ9L/Q5U403+bZMXQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.37.0",
+            "@aws-sdk/types": "3.40.0",
+            "@aws-sdk/util-hex-encoding": "3.37.0",
+            "@aws-sdk/util-uri-escape": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.41.0.tgz",
+          "integrity": "sha512-ldhS0Pf3v6yHCd//kk5DvKcdyeUkKEwxNDRanAp+ekTW68J3XcYgKaPC9sNDhVTDH1zrywTvtEz5zWHEvXjQow==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
+          "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.40.0.tgz",
+          "integrity": "sha512-HwNV+HX7bHgLk5FzTOgdXANsC0SeVz5PMC4Nh+TLz2IoeQnrw4H8dsA4YNonncjern5oC5veKRjQeOoCL5SlSQ==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.37.0.tgz",
+          "integrity": "sha512-tClmH1uYelqWT43xxmnOsVFbCQJiIwizp6y4E109G2LIof07inxrO0L8nbwBpjhugVplx6NZr9IaqTFqbdM1gA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.37.0.tgz",
+          "integrity": "sha512-aY3mXdbEajruRi9CHgq/heM89R+Gectj/Xrs1naewmamaN8NJrvjDm3s+cw//lqqSOW903LYHXDgm7wvCzUnFA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.37.0.tgz",
+          "integrity": "sha512-aa3SBwjLwImuJoE4+hxDIWQ9REz3UFb3p7KFPe9qopdXb/yB12RTcbrXVb4whUux4i4mO6KRij0ZNjFZrjrKPg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.40.0.tgz",
+          "integrity": "sha512-NjZGrA4mqhpr6gkVCAUweurP0Z9d3vFyXJCtulC0BFbpKAnKCf/crSK56NwUaNhAEMCkSuBvjRFzkbfT+HO8bA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.37.0.tgz",
+          "integrity": "sha512-tn5UpfaeM+rZWqynoNqB8lwtcAXil5YYO3HLGH9himpWAdft/2Z7LK6bsYDpctaAI1WHgMDcL0bw3Id04ZUbhA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.37.0.tgz",
+          "integrity": "sha512-8pKf4YJTELP5lm/CEgYw2atyJBB1RWWqFa0sZx6YJmTlOtLF5G6raUdAi4iDa2hldGt2B6IAdIIyuusT8zeU8Q==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.40.0.tgz",
+          "integrity": "sha512-C69sTI26bV2EprTv3DTXu9XP7kD9Wu4YVPBzqztOYArd2GDYw3w+jS8SEg3XRbjAKY/mOPZ2Thw4StjpZlWZiA==",
+          "requires": {
+            "@aws-sdk/types": "3.40.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.40.0.tgz",
+          "integrity": "sha512-cjIzd0hRZFTTh7iLJD6Bciu++Em1iaM1clyG02xRl0JD5DEtDSR1zO02uu+AeM7GSLGOxIvwOkK2j8ySPAOmBA==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.37.0.tgz",
+          "integrity": "sha512-tuiOxzfqet1kKGYzlgpMGfhr64AHJnYsFx2jZiH/O6Yq8XQg43ryjQlbJlim/K/XHGNzY0R+nabeJg34q3Ua1g==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.37.0.tgz",
+          "integrity": "sha512-fUAgd7UTCULL36j9/vnXHxVhxvswnq23mYgTCIT8NQ7wHN30q2a89ym1e9DwGeQkJEBOkOcKLn6nsMsN7YQMDQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-waiter": {
+          "version": "3.40.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.40.0.tgz",
+          "integrity": "sha512-jdxwNEZdID49ZvyAnxaeNm5w2moIfMLOwj/q6TxKlxYoXMs16FQWkhyfGue0vEASzchS49ewbyt+KBqpT31Ebg==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.40.0",
+            "@aws-sdk/types": "3.40.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "3.19.0",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+          "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+        }
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.41.0.tgz",
-      "integrity": "sha512-xDvcy7wv3KdHhOpl5fZN+Ydw+dHBmsCZwMFI1ZdJVCSGO+ZKgl5KVWi1LCif6vjZP1pUuGl44oDOZz1ACqOzTg==",
-      "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/fetch-http-handler": "3.40.0",
-        "@aws-sdk/hash-node": "3.40.0",
-        "@aws-sdk/invalid-dependency": "3.40.0",
-        "@aws-sdk/middleware-content-length": "3.40.0",
-        "@aws-sdk/middleware-host-header": "3.40.0",
-        "@aws-sdk/middleware-logger": "3.40.0",
-        "@aws-sdk/middleware-retry": "3.40.0",
-        "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-stack": "3.40.0",
-        "@aws-sdk/middleware-user-agent": "3.40.0",
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/node-http-handler": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/smithy-client": "3.41.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/url-parser": "3.40.0",
-        "@aws-sdk/util-base64-browser": "3.37.0",
-        "@aws-sdk/util-base64-node": "3.37.0",
-        "@aws-sdk/util-body-length-browser": "3.37.0",
-        "@aws-sdk/util-body-length-node": "3.37.0",
-        "@aws-sdk/util-user-agent-browser": "3.40.0",
-        "@aws-sdk/util-user-agent-node": "3.40.0",
-        "@aws-sdk/util-utf8-browser": "3.37.0",
-        "@aws-sdk/util-utf8-node": "3.37.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/client-sso-oidc": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.209.0.tgz",
-      "integrity": "sha512-KSmT181IcE32lqoZsS0h400qiL/BSQ84DS1iPOqP0NkLcgnvmOkKygVpYjTql2xSUWLQBwPNFihYJ+jmAj3HtQ==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.211.0.tgz",
+      "integrity": "sha512-Wuo3ZYPy9L+OixlZ7/wM1BbPBdC22xO/a8z/J1sgQZiRDl80Ax+jf1u17D91xdZJGH0hTU5AlvEY7mHP0y/hAw==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -18072,528 +15128,194 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
         "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/abort-controller": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
-          "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/config-resolver": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
-          "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
-          "requires": {
-            "@aws-sdk/signature-v4": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-imds": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
-          "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/fetch-http-handler": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
-          "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/querystring-builder": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/hash-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz",
-          "integrity": "sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/invalid-dependency": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz",
-          "integrity": "sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-content-length": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz",
-          "integrity": "sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz",
-          "integrity": "sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz",
-          "integrity": "sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-retry": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
-          "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/service-error-classification": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1",
-            "uuid": "^8.3.2"
-          }
-        },
-        "@aws-sdk/middleware-serde": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
-          "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-stack": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz",
-          "integrity": "sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz",
-          "integrity": "sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-config-provider": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
-          "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-http-handler": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
-          "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
-          "requires": {
-            "@aws-sdk/abort-controller": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/querystring-builder": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/property-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-          "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-          "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-builder": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-          "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-          "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/service-error-classification": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz",
-          "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw=="
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-          "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-          "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
-          "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-          "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-body-length-browser": {
-          "version": "3.188.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-body-length-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-config-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-browser": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
-          "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-node": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
-          "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
-          "requires": {
-            "@aws-sdk/config-resolver": "3.209.0",
-            "@aws-sdk/credential-provider-imds": "3.209.0",
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
-          "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz",
-          "integrity": "sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
-          "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-utf8-browser": {
-          "version": "3.188.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-utf8-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-          "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
-    "@aws-sdk/client-sts": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.43.0.tgz",
-      "integrity": "sha512-4CKYimjhIEixVtJH0Y8FR5FXc7zIepZtfScy8QHgH+DERXm/YL5cuUbkJiL6ZRTpek0vztVvE+mNSQU0z1eXag==",
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.211.0.tgz",
+      "integrity": "sha512-oJ+5ROykVsXpBFpWUfSUYHz/RcTjsZPri6CIY+wQmEFDAOxTsgxd7l8VkqX1r/U/QiK/xDXuK+Z7MurywXS+rQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/credential-provider-node": "3.41.0",
-        "@aws-sdk/fetch-http-handler": "3.40.0",
-        "@aws-sdk/hash-node": "3.40.0",
-        "@aws-sdk/invalid-dependency": "3.40.0",
-        "@aws-sdk/middleware-content-length": "3.40.0",
-        "@aws-sdk/middleware-host-header": "3.40.0",
-        "@aws-sdk/middleware-logger": "3.40.0",
-        "@aws-sdk/middleware-retry": "3.40.0",
-        "@aws-sdk/middleware-sdk-sts": "3.40.0",
-        "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.40.0",
-        "@aws-sdk/middleware-stack": "3.40.0",
-        "@aws-sdk/middleware-user-agent": "3.40.0",
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/node-http-handler": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/smithy-client": "3.41.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/url-parser": "3.40.0",
-        "@aws-sdk/util-base64-browser": "3.37.0",
-        "@aws-sdk/util-base64-node": "3.37.0",
-        "@aws-sdk/util-body-length-browser": "3.37.0",
-        "@aws-sdk/util-body-length-node": "3.37.0",
-        "@aws-sdk/util-user-agent-browser": "3.40.0",
-        "@aws-sdk/util-user-agent-node": "3.40.0",
-        "@aws-sdk/util-utf8-browser": "3.37.0",
-        "@aws-sdk/util-utf8-node": "3.37.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.211.0.tgz",
+      "integrity": "sha512-39/PMIKLEaRUztx3m4I0x9SCnqTStaQuqIabAK/wk0uy+O2p32sv7eacRrGjZWHngqdsK7S1s/LSFErYzzIvkw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.211.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-sdk-sts": "3.208.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-signing": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.40.0.tgz",
-      "integrity": "sha512-QYy6J2k31QL6J74hPBfptnLW1kQYdN+xjwH4UQ1mv7EUhRoJN9ZY2soStJowFy4at6IIOOVWbyG5dyqvrbEovg==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
+      "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-config-provider": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/signature-v4": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.40.0.tgz",
-      "integrity": "sha512-qHZdf2vxhzZkSygjw2I4SEYFL2dMZxxYvO4QlkqQouKY81OVxs/j69oiNCjPasQzGz5jaZZKI8xEAIfkSyr1lg==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz",
+      "integrity": "sha512-FB+KUSpZc03wVTXxGnMmgtaP0sJOv0D7oyogHb7wcf5b7RjjwqoaeUcJHTdKRZaW6e1foLk3/L9uebxiWefDbQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.40.0.tgz",
-      "integrity": "sha512-Ty/wVa+BQrCFrP06AGl5S1CeLifDt68YrlYXUnkRn603SX4DvxBgVO7XFeDH58G8ziDCiqxfmVl4yjbncPPeSw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
+      "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/url-parser": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.41.0.tgz",
-      "integrity": "sha512-98CGEHg7Tb6HxK5ZIdbAcijvD3IpLe0ddse1xMe/Ilhjz770FS/L2UNprOP6PZTqrSfBffiMrvfThUSuUaTlIQ==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.211.0.tgz",
+      "integrity": "sha512-kFekBDGX3tMsbEBjpCHt2dp5hx7xBN0d7v+fNXky4fB61bNUxcLNpXkTgDIqRyMzEje3Jov9Be9Qgqb8ud0Fiw==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.40.0",
-        "@aws-sdk/credential-provider-imds": "3.40.0",
-        "@aws-sdk/credential-provider-sso": "3.41.0",
-        "@aws-sdk/credential-provider-web-identity": "3.41.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-credentials": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/credential-provider-env": "3.208.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.211.0",
+        "@aws-sdk/credential-provider-web-identity": "3.208.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.41.0.tgz",
-      "integrity": "sha512-5FW6+wNJgyDCsbAd+mLm/1DBTDkyIYOMVzcxbr6Vi3pM4UrMFdeLdAP62edYW8usg78Xg+c6vaAoEv/M3zkS0Q==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.211.0.tgz",
+      "integrity": "sha512-RWDitzHmZOfrfTZCnL8nOLQgYgawAAw8IF5pqeNjcN9TZ/pR64B9pusTYD7a+uVDB8kb9vMU767g89ts2pqmfQ==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.40.0",
-        "@aws-sdk/credential-provider-imds": "3.40.0",
-        "@aws-sdk/credential-provider-ini": "3.41.0",
-        "@aws-sdk/credential-provider-process": "3.40.0",
-        "@aws-sdk/credential-provider-sso": "3.41.0",
-        "@aws-sdk/credential-provider-web-identity": "3.41.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-credentials": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/credential-provider-env": "3.208.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/credential-provider-ini": "3.211.0",
+        "@aws-sdk/credential-provider-process": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.211.0",
+        "@aws-sdk/credential-provider-web-identity": "3.208.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.40.0.tgz",
-      "integrity": "sha512-qsaNCDesW2GasDbzpeOA371gxugi05JWxt3EKonLbUfkGKBK7kmmL6EgLIxZuNm2/Ve4RS07PKp8yBGm4xIx9w==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz",
+      "integrity": "sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==",
       "requires": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-credentials": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.41.0.tgz",
-      "integrity": "sha512-9s7SWu3RVIQ/MTcBCt35EMzxNQm3avivrbpSOKfJwxR5L+oNKPsV+gSqMlkNZGwOVJyUicIsZGcq/4ON6CjrOg==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.211.0.tgz",
+      "integrity": "sha512-S8ciHRypUCi0Uz0D80yVGkWmvpCBCvkEaj+IO0LdYX05GDnH/B44DA8UQ0pfAJqLy5BeSO5snKVRKSPzxNtUGw==",
       "requires": {
-        "@aws-sdk/client-sso": "3.41.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-credentials": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/client-sso": "3.211.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/token-providers": "3.211.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.41.0.tgz",
-      "integrity": "sha512-VqvVoEh9C8xTXl4stKyJC5IKQhS8g1Gi5k6B9HPHLIxFRRfKxkE73DT4pMN6npnus7o0yi0MTFGQFQGYSrFO2g==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.208.0.tgz",
+      "integrity": "sha512-7wtrdEr8uvDr5t0stimrXGsW4G+TQyluZ9OucCCY0HXgNihmnk1BIu+COuOSxRtFXHwCh4rIPaVE1ABG2Mq24g==",
       "requires": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/endpoint-cache": {
@@ -18603,21 +15325,6 @@
       "requires": {
         "mnemonist": "0.38.3",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "mnemonist": {
-          "version": "0.38.3",
-          "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
-          "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
-          "requires": {
-            "obliterator": "^1.6.1"
-          }
-        },
-        "obliterator": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
-          "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
-        }
       }
     },
     "@aws-sdk/eventstream-codec": {
@@ -18629,21 +15336,6 @@
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/util-hex-encoding": "3.201.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
@@ -18654,13 +15346,6 @@
         "@aws-sdk/eventstream-serde-universal": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
@@ -18670,13 +15355,6 @@
       "requires": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/eventstream-serde-node": {
@@ -18687,13 +15365,6 @@
         "@aws-sdk/eventstream-serde-universal": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
@@ -18704,25 +15375,18 @@
         "@aws-sdk/eventstream-codec": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.40.0.tgz",
-      "integrity": "sha512-w1HiZromoU+/bbEo89uO81l6UO/M+c2uOMnXntZqe6t3ZHUUUo3AbvhKh0QGVFqRQa+Oi0+95KqWmTHa72/9Iw==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
+      "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/querystring-builder": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-base64-browser": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/querystring-builder": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-blob-browser": {
@@ -18734,23 +15398,16 @@
         "@aws-sdk/chunked-blob-reader-native": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.40.0.tgz",
-      "integrity": "sha512-yOXXK85DdGDktdnQtXgMdaVKii4wtMjEhJ1mrvx2A9nMFNaPhxvERkVVIUKSWlJRa9ZujOw5jWOx8d2R51/Kjg==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz",
+      "integrity": "sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-buffer-from": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-stream-node": {
@@ -18760,30 +15417,23 @@
       "requires": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.40.0.tgz",
-      "integrity": "sha512-axIWtDwCBDDqEgAJipX1FB1ZNpWYXquVwKDMo+7G+ftPBZ4FEq4M1ELhXJL3hhNJ9ZmCQzv+4F6Wnt8dwuzUaQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz",
+      "integrity": "sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.37.0.tgz",
-      "integrity": "sha512-XLjA/a6AuGnCvcJZLsMTy2jxF2upgGhqCCkoIJgLlzzXHSihur13KcmPvW/zcaGnCRj0SvKWXiJHl4vDlW75VQ==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/md5-js": {
@@ -18795,47 +15445,6 @@
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-utf8-browser": {
-          "version": "3.188.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-utf8-node": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-          "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
@@ -18848,40 +15457,16 @@
         "@aws-sdk/util-arn-parser": "3.208.0",
         "@aws-sdk/util-config-provider": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-          "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        },
-        "@aws-sdk/util-config-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.40.0.tgz",
-      "integrity": "sha512-sybAJb8v7I/vvL08R3+TI/XDAg9gybQTZ2treC24Ap4+jAOz4QBTHJPMKaUlEeFlMUcq4rj6/u2897ebYH6opw==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz",
+      "integrity": "sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-endpoint": {
@@ -18897,180 +15482,18 @@
         "@aws-sdk/util-config-provider": "3.208.0",
         "@aws-sdk/util-middleware": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-serde": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
-          "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-          "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-          "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-          "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-          "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-config-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.208.0.tgz",
-      "integrity": "sha512-RSbqxZ/oVBY7VvIjwm8ZrpcI4jd+oZZJVXNA2H++J12yEVGNLYOFXZzUatq+Z8ryfuugdsvfMYvVA64qzT8rQw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.209.0.tgz",
+      "integrity": "sha512-ZBWYhTBfdc/bUNB1N4jL8ZW7NmKTkdowbZHTlxtXi8ySzzn+qlD+XosIEbXqrVR9sYxSVC3kwsQvADxHzKGixw==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.208.0",
+        "@aws-sdk/config-resolver": "3.209.0",
         "@aws-sdk/endpoint-cache": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/config-resolver": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.208.0.tgz",
-          "integrity": "sha512-eLwI7rjk3AJj/S8PqRcUi9iBD+cTm1Nzu1CmYyeiwU6YbJLe5/2CrhW1wjkOGleE+aD967U1TWiB18tsx6fj+w==",
-          "requires": {
-            "@aws-sdk/signature-v4": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-          "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-          "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        },
-        "@aws-sdk/util-config-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-expect-continue": {
@@ -19081,22 +15504,6 @@
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-          "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
@@ -19110,40 +15517,16 @@
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-          "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.40.0.tgz",
-      "integrity": "sha512-/wocR7JFOLM7/+BQM1DgAd6KCFYcdxYu1P7AhI451GlVNuYa5f89zh7p0gt3SRC6monI5lXgpL7RudhDm8fTrA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz",
+      "integrity": "sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-location-constraint": {
@@ -19153,22 +15536,15 @@
       "requires": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.40.0.tgz",
-      "integrity": "sha512-19kx0Xg5ymVRKoupmhdmfTBkROcv3DZj508agpyG2YAo0abOObMlIP4Jltg0VD4PhNjGzNh0jFGJnvhjdwv4/A==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz",
+      "integrity": "sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
@@ -19179,33 +15555,18 @@
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-          "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.40.0.tgz",
-      "integrity": "sha512-SMUJrukugLL7YJE5X8B2ToukxMWMPwnf7jAFr84ptycCe8bdWv8x8klQ3EtVWpyqochtNlbTi6J/tTQBniUX7A==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
+      "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/service-error-classification": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/service-error-classification": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-middleware": "3.208.0",
+        "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       }
     },
@@ -19219,56 +15580,41 @@
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/util-arn-parser": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-          "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.40.0.tgz",
-      "integrity": "sha512-TcrbCvj1PkabFZiNczT3yePZtuEm2fAIw1OVnQyLcF2KW+p62Hv5YkK4MPOfx3LA/0lzjOUO1RNl2x7gzV443Q==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.208.0.tgz",
+      "integrity": "sha512-lFVodZHYLF7puXgNZ1m5ycKbyCPp79nqI+pkRXl066ZtZWzCW8+JKCaLjF3jfXlnvg6foPDJdxUvt0VU5EddGg==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.40.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/signature-v4": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-signing": "3.208.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/signature-v4": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.40.0.tgz",
-      "integrity": "sha512-uOWfZjlAoBy6xPqp0d4ka83WNNbEVCWn9WwfqBUXThyoTdTooYSpXe5y2YzN0BJa8b+tEZTyWpgamnBpFLp47g==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
+      "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.40.0.tgz",
-      "integrity": "sha512-RqK5nPbfma0qInMvjtpVkDYY/KkFS6EKlOv3DWTdxbXJ4YuOxgKiuUromhmBUoyjFag0JO7LUWod07H+/DawoA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.208.0.tgz",
+      "integrity": "sha512-cMSWhg8xOrxZw04EYKEQQQ7RT+03rigS4KS3Uy6x/M+jFyoM+sRiY/7376sJCwlpvKH2xJIVpwPbKk/uz4j4DA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/signature-v4": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/signature-v4": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-middleware": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-ssec": {
@@ -19278,116 +15624,111 @@
       "requires": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.40.0.tgz",
-      "integrity": "sha512-hby9HvESUYJxpdALX+6Dn2LPmS5jtMVurGB/+j3MWOvIcDYB4bcSXgVRvXzYnTKwbSupIdbX9zOE2ZAx2SJpUQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz",
+      "integrity": "sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.40.0.tgz",
-      "integrity": "sha512-dzC2fxWnanetFJ1oYgil8df3N36bR1yc/OCOpbdfQNiUk1FrXiCXqH5rHNO8zCvnwJAj8GHFwpFGd9a2Qube2w==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz",
+      "integrity": "sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.40.0.tgz",
-      "integrity": "sha512-AmokjgUDECG8osoMfdRsPNweqI+L1pn4bYGk5iTLmzbBi0o4ot0U1FdX8Rf0qJZZwS4t1TXc3s8/PDVknmPxKg==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
+      "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.40.0.tgz",
-      "integrity": "sha512-qjda6IbxDhbYr8NHmrMurKkbjgLUkfTMVgagDErDK24Nm3Dn5VaO6J4n6c0Q4OLHlmFaRcUfZSTrOo5DAubqCw==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
+      "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/querystring-builder": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/abort-controller": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/querystring-builder": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.40.0.tgz",
-      "integrity": "sha512-Mx4lkShjsYRwW9ujHA1pcnuubrWQ4kF5/DXWNfUiXuSIO/0Lojp1qTLheyBm4vzkJIlx5umyP6NvRAUkEHSN4Q==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
+      "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.40.0.tgz",
-      "integrity": "sha512-f4ea7/HZkjpvGBrnRIuzc/bhrExWrgDv7eulj4htPukZGHdTqSJD3Jk8lEXWvFuX2vUKQDGhEhCDsqup7YWJQQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
+      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.40.0.tgz",
-      "integrity": "sha512-gO24oipnNaxJRBXB7lhLfa96vIMOd8gtMBqJTjelTjS2e1ZP1YY12CNKKTWwafSk8Ge021erZAG/YTOaXGpv+g==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
+      "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-uri-escape": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.40.0.tgz",
-      "integrity": "sha512-XZIyaKQIiZAM6zelCBcsLHhVDOLafi7XIOd3jy6SymGN8ajj3HqUJ/vdQ5G6ISTk18OrqgqcCOI9oNzv+nrBcA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
+      "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.40.0.tgz",
-      "integrity": "sha512-c8btKmkvjXczWudXubGdbO3JgmjySBUVC/gCrZDNfwNGsG8RYJJQYYcnmt1gWjelUZsgMDl/2PIzxTlxVF91rA=="
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz",
+      "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.37.0.tgz",
-      "integrity": "sha512-+vRBSlfa48R9KL7DpQt3dsu5/+5atjRgoCISblWo3SLpjrx41pKcjKneo7a1u0aP1Xc2oG2TfIyqTWZuOXsmEQ==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
+      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
       "requires": {
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.40.0.tgz",
-      "integrity": "sha512-Q1GNZJRCS3W2qsRtDsX/b6EOSfMXfr6TW46N3LnLTGYZ3KAN2SOSJ1DsW59AuGpEZyRmOhJ9L/Q5U403+bZMXQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
+      "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-hex-encoding": "3.37.0",
-        "@aws-sdk/util-uri-escape": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.208.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
@@ -19400,121 +15741,43 @@
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/util-arn-parser": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-          "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-          "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.41.0.tgz",
-      "integrity": "sha512-ldhS0Pf3v6yHCd//kk5DvKcdyeUkKEwxNDRanAp+ekTW68J3XcYgKaPC9sNDhVTDH1zrywTvtEz5zWHEvXjQow==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
+      "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.209.0.tgz",
-      "integrity": "sha512-MMtL/yD98SxjejcZYghLN4qhC1TDNeHjnzb+zBcXANxgh5m+QdhERsZkDGU8QiEo+DL6M2HKbwyXu82z89sqnQ==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.211.0.tgz",
+      "integrity": "sha512-dxdUT+JKCl9krmBQde1HeV6rwYP+ZTBkfx5vIa3PdfDI7XljRBf1XdE0mS18eSURfQA7v969Y5sJ6/rFyjT/QA==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.209.0",
+        "@aws-sdk/client-sso-oidc": "3.211.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/property-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-          "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-          "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA=="
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
+      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
     },
     "@aws-sdk/url-parser": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.40.0.tgz",
-      "integrity": "sha512-HwNV+HX7bHgLk5FzTOgdXANsC0SeVz5PMC4Nh+TLz2IoeQnrw4H8dsA4YNonncjern5oC5veKRjQeOoCL5SlSQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
+      "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/querystring-parser": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-arn-parser": {
@@ -19532,25 +15795,6 @@
       "requires": {
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/util-base64-browser": {
@@ -19568,39 +15812,58 @@
       "requires": {
         "@aws-sdk/util-buffer-from": "3.37.0",
         "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.37.0.tgz",
+          "integrity": "sha512-XLjA/a6AuGnCvcJZLsMTy2jxF2upgGhqCCkoIJgLlzzXHSihur13KcmPvW/zcaGnCRj0SvKWXiJHl4vDlW75VQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.37.0.tgz",
+          "integrity": "sha512-aa3SBwjLwImuJoE4+hxDIWQ9REz3UFb3p7KFPe9qopdXb/yB12RTcbrXVb4whUux4i4mO6KRij0ZNjFZrjrKPg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.37.0",
+            "tslib": "^2.3.0"
+          }
+        }
       }
     },
     "@aws-sdk/util-body-length-browser": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.37.0.tgz",
-      "integrity": "sha512-tClmH1uYelqWT43xxmnOsVFbCQJiIwizp6y4E109G2LIof07inxrO0L8nbwBpjhugVplx6NZr9IaqTFqbdM1gA==",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.37.0.tgz",
-      "integrity": "sha512-aY3mXdbEajruRi9CHgq/heM89R+Gectj/Xrs1naewmamaN8NJrvjDm3s+cw//lqqSOW903LYHXDgm7wvCzUnFA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.37.0.tgz",
-      "integrity": "sha512-aa3SBwjLwImuJoE4+hxDIWQ9REz3UFb3p7KFPe9qopdXb/yB12RTcbrXVb4whUux4i4mO6KRij0ZNjFZrjrKPg==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-config-provider": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.40.0.tgz",
-      "integrity": "sha512-NjZGrA4mqhpr6gkVCAUweurP0Z9d3vFyXJCtulC0BFbpKAnKCf/crSK56NwUaNhAEMCkSuBvjRFzkbfT+HO8bA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-credentials": {
@@ -19610,202 +15873,65 @@
       "requires": {
         "@aws-sdk/shared-ini-file-loader": "3.37.0",
         "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.37.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.37.0.tgz",
+          "integrity": "sha512-+vRBSlfa48R9KL7DpQt3dsu5/+5atjRgoCISblWo3SLpjrx41pKcjKneo7a1u0aP1Xc2oG2TfIyqTWZuOXsmEQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        }
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.208.0.tgz",
-      "integrity": "sha512-i4cA074pycou1BPr7axFMiK3iHv+Tzjl/ZiN3Yc0BQDLWC9AQdrNodB4WAKnn4a4fWgA/MadfzKXnW1oltSzIg==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
+      "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
       "requires": {
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/property-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-          "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.208.0.tgz",
-      "integrity": "sha512-y9dENqcmiUb7/D3uwJsE/fV+RZ9CUc/cs4OcofO81sU29xz8Fg/XQarjSdGVZMTnrDd190GXymMcB4qpOYhtPw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
+      "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/config-resolver": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.208.0.tgz",
-          "integrity": "sha512-eLwI7rjk3AJj/S8PqRcUi9iBD+cTm1Nzu1CmYyeiwU6YbJLe5/2CrhW1wjkOGleE+aD967U1TWiB18tsx6fj+w==",
-          "requires": {
-            "@aws-sdk/signature-v4": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-imds": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.208.0.tgz",
-          "integrity": "sha512-z4Bk42FQefBzS1SZ6/4gsAFE7tQhEoDmSUrFVSDu/9WwvGpFMnFfHLTBhivlcAHjc/eQ/hiWYLnQ8vahqhHl8w==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-config-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.208.0.tgz",
-          "integrity": "sha512-htjs1cDXYXEMwZ1q2vb7wfG3bOW4weWWkKcfT7vqzZKfTXoMH2mPpJIXnPE1PxXerOLXHGUU8qqhfl6LxjlnfQ==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/property-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-          "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-          "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.208.0.tgz",
-          "integrity": "sha512-ZDmwOLNiBKfvtN1M2eG2bItw0+4hKDU/XKqB+yVI9Uo29o4XwtQ4Br7HixTlPYJAavmM1cCch8PVvnwngYAKPA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-          "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-          "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-config-provider": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/util-dynamodb": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.208.0.tgz",
-      "integrity": "sha512-4tJNlsZ2wpaQVxQ+AwXGmUk3lLWBrqK4lpJYITJ1C6Y8VZF/yqjeH+mNGQifMzO3T4dzCuGBCUKJ1HUCmGApCw==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.211.0.tgz",
+      "integrity": "sha512-XvtGV2sDmS8ZQMnztWQlVxPJ90iTL13IhHfOiDGp3gGzSLow8pNzBfw3+xmxFAtu0Q2XfSmFb/F/vyPt2SzcnQ==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.208.0.tgz",
-      "integrity": "sha512-FGJA07iEbC883bAaw0qtDrly5Y+1nR3ic+OOzGX2AsSgaeVAc1j8Lgg3br7ofBbr8p81ec6zN4syy4v7V0Wb0A==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.211.0.tgz",
+      "integrity": "sha512-FY0h897WFltaUBF5aedLCBP2OlxN0aIqrInAa7aYGz3HsUTl97liHTii34bZrMJQHxmfcKBXAsjV1jJGc2orLw==",
       "requires": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        }
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.37.0.tgz",
-      "integrity": "sha512-tn5UpfaeM+rZWqynoNqB8lwtcAXil5YYO3HLGH9himpWAdft/2Z7LK6bsYDpctaAI1WHgMDcL0bw3Id04ZUbhA==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-locate-window": {
@@ -19835,68 +15961,6 @@
         "@aws-sdk/util-hex-encoding": "3.201.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/fetch-http-handler": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
-          "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/querystring-builder": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-          "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-builder": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-          "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-utf8-browser": {
-          "version": "3.188.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/util-stream-node": {
@@ -19908,133 +15972,61 @@
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/abort-controller": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
-          "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-http-handler": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
-          "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
-          "requires": {
-            "@aws-sdk/abort-controller": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/querystring-builder": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-          "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-builder": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-          "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-          "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.208.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/util-uri-escape": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.37.0.tgz",
-      "integrity": "sha512-8pKf4YJTELP5lm/CEgYw2atyJBB1RWWqFa0sZx6YJmTlOtLF5G6raUdAi4iDa2hldGt2B6IAdIIyuusT8zeU8Q==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.40.0.tgz",
-      "integrity": "sha512-C69sTI26bV2EprTv3DTXu9XP7kD9Wu4YVPBzqztOYArd2GDYw3w+jS8SEg3XRbjAKY/mOPZ2Thw4StjpZlWZiA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz",
+      "integrity": "sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/types": "3.208.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.40.0.tgz",
-      "integrity": "sha512-cjIzd0hRZFTTh7iLJD6Bciu++Em1iaM1clyG02xRl0JD5DEtDSR1zO02uu+AeM7GSLGOxIvwOkK2j8ySPAOmBA==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
+      "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-utf8-browser": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.37.0.tgz",
-      "integrity": "sha512-tuiOxzfqet1kKGYzlgpMGfhr64AHJnYsFx2jZiH/O6Yq8XQg43ryjQlbJlim/K/XHGNzY0R+nabeJg34q3Ua1g==",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-utf8-node": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.37.0.tgz",
-      "integrity": "sha512-fUAgd7UTCULL36j9/vnXHxVhxvswnq23mYgTCIT8NQ7wHN30q2a89ym1e9DwGeQkJEBOkOcKLn6nsMsN7YQMDQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.37.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.40.0.tgz",
-      "integrity": "sha512-jdxwNEZdID49ZvyAnxaeNm5w2moIfMLOwj/q6TxKlxYoXMs16FQWkhyfGue0vEASzchS49ewbyt+KBqpT31Ebg==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.208.0.tgz",
+      "integrity": "sha512-DEMVnoZXLUXeakBDMe9IhZ8VQCVf/5cMlNtE+4EpSVvH8CEE0Qfc0nDjrTYEkLpAIZWRL3tpHx61MMKvgCirXA==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/abort-controller": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/xml-builder": {
@@ -20233,9 +16225,9 @@
       "dev": true
     },
     "@ipld/car": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.0.0.tgz",
-      "integrity": "sha512-JyJ5vGEIyheqxmJKa81eQdd9tScOKpkO1wcGQPsm/DbV87n0wT7KvzaFOLSZCcPoq23+C5u+GIwFV+CBUVBGOw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.0.1.tgz",
+      "integrity": "sha512-YPXr1TztVmTPE4MerjKpFMuIll73MqvEakzWDMqj4uGJnwkY+tE0SlBGmqkMSofOgVMQAxZ6JtuRA93WlTzb8w==",
       "requires": {
         "@ipld/dag-cbor": "^8.0.0",
         "cborg": "^1.9.0",
@@ -20355,14 +16347,14 @@
       }
     },
     "@serverless-stack/cli": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/cli/-/cli-1.17.1.tgz",
-      "integrity": "sha512-fwv1tHki4U+6hOSdvfO32axP4hySW0DEvSQDkWudofxGSQ0nimeNCIMqce49pEp2gfJscHr2Qv71hGAbEpJhhQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/cli/-/cli-1.18.0.tgz",
+      "integrity": "sha512-W2Bh6Tk+X4QzyN9KS+rTrWXSGxlalfxUafGy8TDjyZIa3TILgAl2HgHH/kB3NdfTxkxfrOdFcNL89DdbutHapw==",
       "dev": true,
       "requires": {
         "@aws-cdk/aws-apigatewayv2-alpha": "2.50.0-alpha.0",
-        "@serverless-stack/core": "1.17.1",
-        "@serverless-stack/resources": "1.17.1",
+        "@serverless-stack/core": "1.18.0",
+        "@serverless-stack/resources": "1.18.0",
         "aws-cdk": "2.50.0",
         "aws-cdk-lib": "2.50.0",
         "aws-sdk": "^2.1110.0",
@@ -20382,9 +16374,9 @@
       }
     },
     "@serverless-stack/core": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/core/-/core-1.17.1.tgz",
-      "integrity": "sha512-gR+cxYJdb4cDcyh5Pw6USjVKzOuD+1iLA+yr1Y5dB30U181y8PE+NpAjv9D2LQzLQBGfnyWVFqlZvYSr+8Sd0A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/core/-/core-1.18.0.tgz",
+      "integrity": "sha512-Qg30siJrmH3/cAchs+svkcrNObUv1dUy1mOJ0aNoQXXsvxXQryxNi9Kouswn7szGvOGDcioNvn2+V08IEzmrjQ==",
       "dev": true,
       "requires": {
         "@pothos/core": "^3.11.0",
@@ -20413,7 +16405,7 @@
         "immer": "^9.0.7",
         "js-yaml": "^4.1.0",
         "kysely": "^0.21.3",
-        "kysely-codegen": "^0.6.0",
+        "kysely-codegen": "^0.6.1",
         "kysely-data-api": "^0.1.2",
         "log4js": "^6.3.0",
         "picomatch": "^2.3.0",
@@ -20427,9 +16419,9 @@
       }
     },
     "@serverless-stack/node": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/node/-/node-1.17.1.tgz",
-      "integrity": "sha512-hfByLWtjhMrvOZ5dkkjX1Z5oht/U9iUWeVc7doXrwqtQTbRBnWgKx/v19sNGwt+TW+zrfY1dLeP5RTwt/me4bA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/node/-/node-1.18.0.tgz",
+      "integrity": "sha512-S5tKbz9i/P8YS5TqZD1XYSmi22n+H3qbCjyaGXBSB/P/i5VuHiJJCP7l1eBO/p+aa7VwdNJgVUy/Yp4NaxSiqA==",
       "requires": {
         "@aws-sdk/client-lambda": "3.43.0",
         "@aws-sdk/client-ssm": "3.43.0",
@@ -20444,9 +16436,9 @@
       }
     },
     "@serverless-stack/resources": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/resources/-/resources-1.17.1.tgz",
-      "integrity": "sha512-CG/0fIU2PCQGEPLChCkOPTl96LF+tv/ccb8CuWG0sIslyk1KMUC5tYvlA8OyP1xcV+DQv0oMkOWvbbdlRgmNrg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/resources/-/resources-1.18.0.tgz",
+      "integrity": "sha512-SKZKZCqlOhlDKJLnLi5wQfkaaEejaezHkePVtvclYv3u+IC7SEOf8BqOXsXnKuupANYw4uIQ+vujaK92zzzv1g==",
       "dev": true,
       "requires": {
         "@aws-cdk/aws-apigatewayv2-alpha": "2.50.0-alpha.0",
@@ -20454,7 +16446,7 @@
         "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.50.0-alpha.0",
         "@aws-cdk/aws-appsync-alpha": "2.50.0-alpha.0",
         "@aws-sdk/client-codebuild": "^3.169.0",
-        "@serverless-stack/core": "1.17.1",
+        "@serverless-stack/core": "1.18.0",
         "archiver": "^5.3.0",
         "aws-cdk-lib": "2.50.0",
         "chalk": "^4.1.0",
@@ -20516,9 +16508,9 @@
       }
     },
     "@types/dockerode": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.12.tgz",
-      "integrity": "sha512-9dCtVq6Nr4XkkJmjyiDYOfZWVQ8MpJ35RZNawJYFLjd1VuaFLboDoIcyar23BkpMLeYzp6+vT8Vp3GHjhhlY+w==",
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.13.tgz",
+      "integrity": "sha512-0q7tbf2z/4cP3hmgENF9y4TsaIpeEP2Hzx3W8ABEdNvDiflIeN8O1oKIbfdOUg2+II5U9QRMTVRHF7PkIR45OA==",
       "dev": true,
       "requires": {
         "@types/docker-modem": "*",
@@ -20617,14 +16609,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.1.tgz",
-      "integrity": "sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.43.0.tgz",
+      "integrity": "sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/type-utils": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/type-utils": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -20634,62 +16626,62 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.42.1.tgz",
-      "integrity": "sha512-qona75z2MLpeZADEuCet5Pwvh1g/0cWScEEDy43chuUPc4klgDiwz5hLFk5dHcjFEETSYQHRPYiiHKW24EMPjw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.43.0.tgz",
+      "integrity": "sha512-WkT637CumTJbm/hRbFfnHBMgfUYTKr08LitVsD7gQId7bi6rnkx3pu3jac67lmp5ObW4MpJ9SNFZAIOUB/Qbsw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.42.1"
+        "@typescript-eslint/utils": "5.43.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.1.tgz",
-      "integrity": "sha512-kAV+NiNBWVQDY9gDJDToTE/NO8BHi4f6b7zTsVAJoTkmB/zlfOpiEVBzHOKtlgTndCKe8vj9F/PuolemZSh50Q==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.43.0.tgz",
+      "integrity": "sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.1.tgz",
-      "integrity": "sha512-QAZY/CBP1Emx4rzxurgqj3rUinfsh/6mvuKbLNMfJMMKYLRBfweus8brgXF8f64ABkIZ3zdj2/rYYtF8eiuksQ==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.43.0.tgz",
+      "integrity": "sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1"
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/visitor-keys": "5.43.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.1.tgz",
-      "integrity": "sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.43.0.tgz",
+      "integrity": "sha512-K21f+KY2/VvYggLf5Pk4tgBOPs2otTaIHy2zjclo7UZGLyFH86VfUOm5iq+OtDtxq/Zwu2I3ujDBykVW4Xtmtg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/typescript-estree": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.1.tgz",
-      "integrity": "sha512-Qrco9dsFF5lhalz+lLFtxs3ui1/YfC6NdXu+RAGBa8uSfn01cjO7ssCsjIsUs484vny9Xm699FSKwpkCcqwWwA==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.43.0.tgz",
+      "integrity": "sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.1.tgz",
-      "integrity": "sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.43.0.tgz",
+      "integrity": "sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/visitor-keys": "5.43.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -20714,50 +16706,50 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.1.tgz",
-      "integrity": "sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.43.0.tgz",
+      "integrity": "sha512-8nVpA6yX0sCjf7v/NDfeaOlyaIIqL7OaIGOWSPFqUKK59Gnumd3Wa+2l8oAaYO2lk0sO+SbWFWRSvhu8gLGv4A==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.1.tgz",
-      "integrity": "sha512-LOQtSF4z+hejmpUvitPlc4hA7ERGoj2BVkesOcG91HCn8edLGUXbTrErmutmPbl8Bo9HjAvOO/zBKQHExXNA2A==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.43.0.tgz",
+      "integrity": "sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.42.1",
+        "@typescript-eslint/types": "5.43.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
     "@ucanto/client": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-3.0.1.tgz",
-      "integrity": "sha512-rK0M3kqLHlvLTp6P9jyqjSOdzGbulawxzfFOh0cV4D6FLLjpHwNq5NpXZ7n6AbQ7H1EQeWla/gNgLKVGWXKrMQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-3.0.2.tgz",
+      "integrity": "sha512-viYv/fLPvH/POFIfVoIaK4B8KSYIBLNZeVFCdnhSbS4/m6t3h4G0Z7GMjNyP1mZG/CGjAOmHxeNvMUr0sNCyVQ==",
       "requires": {
-        "@ucanto/interface": "^3.0.0",
-        "multiformats": "^10.0.0"
+        "@ucanto/interface": "^3.0.1",
+        "multiformats": "^10.0.2"
       }
     },
     "@ucanto/core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-3.0.1.tgz",
-      "integrity": "sha512-DoCIfczxo6bikOUFA/5RS6QTC52Xz2Dfija5rsWmRj+vP8LIvuuuNhHZbgDEmXtSRVyvoVQeAxxxHmWWrVtoAQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-3.0.2.tgz",
+      "integrity": "sha512-TEVCqAM/3v4fXLuZcIBgQZrPwD53yqoXqwmSChhd420FikFGkkAeWvj6JT6oR4VmCuiIPK5FnukaE2LL5h0Ekg==",
       "requires": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-ucan": "^2.0.0",
-        "@ucanto/interface": "^3.0.0",
-        "multiformats": "^10.0.0"
+        "@ucanto/interface": "^3.0.1",
+        "multiformats": "^10.0.2"
       }
     },
     "@ucanto/interface": {
@@ -20770,49 +16762,49 @@
       }
     },
     "@ucanto/principal": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-3.0.0.tgz",
-      "integrity": "sha512-7CwVbYQc+CdWta+lNuI6vRjVT+GkPwf2VQVXFBm8i4fQomFOTmOq8I/Be3TBS9N2OaIbL7b/eKy1WBdMMzfz5g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-3.0.1.tgz",
+      "integrity": "sha512-0U0EF2ddfR55LKKc7FkzTkH8OFvjZvEeRqMkyV5FyeSsFEF7lXhgEXZrNgggK2zlriXjYC9VVCpPhsGb4cI72g==",
       "requires": {
         "@ipld/dag-ucan": "^2.0.0",
         "@noble/ed25519": "^1.7.1",
-        "@ucanto/interface": "^3.0.0",
-        "multiformats": "^10.0.0",
+        "@ucanto/interface": "^3.0.1",
+        "multiformats": "^10.0.2",
         "one-webcrypto": "^1.0.3"
       }
     },
     "@ucanto/server": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/server/-/server-3.0.1.tgz",
-      "integrity": "sha512-PMBb9gPk+5+qKl7bANusPq9xCm2S0dVNIT33EmmtNhXWQSj8nLvWLInnxXYGc+ziyQonPZtDPgKi02uREFEdXw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@ucanto/server/-/server-3.0.4.tgz",
+      "integrity": "sha512-4a5ou5HZ8ymw39EeZ0024nu0JD916xTMpYsS4eXMxpnoWlOjgmoeWZ5e01dEiw5AlfnSa8e9+a0b1dzvSISQxQ==",
       "requires": {
-        "@ucanto/core": "^3.0.1",
-        "@ucanto/interface": "^3.0.0",
-        "@ucanto/validator": "^3.0.1"
+        "@ucanto/core": "^3.0.2",
+        "@ucanto/interface": "^3.0.1",
+        "@ucanto/validator": "^3.0.4"
       }
     },
     "@ucanto/transport": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-3.0.1.tgz",
-      "integrity": "sha512-stUryA8e6Npkt8RVcxko61gE11+c2Gta+eGzv1XOrWGCk5WqdzequWs/zLxgHxq52EqCWZhLYKQpY5nkrz5UAA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-3.0.2.tgz",
+      "integrity": "sha512-IyfI26VWPxCL2jnGiGP1i6mZblk8QORHzEVt5t+7Pic2k7pANQHoqbveQveRb9a8z6D/UdFogSPQxWYYtKaxWQ==",
       "requires": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-cbor": "^8.0.0",
-        "@ucanto/core": "^3.0.1",
-        "@ucanto/interface": "^3.0.0",
-        "multiformats": "^10.0.0"
+        "@ucanto/core": "^3.0.2",
+        "@ucanto/interface": "^3.0.1",
+        "multiformats": "^10.0.2"
       }
     },
     "@ucanto/validator": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-3.0.1.tgz",
-      "integrity": "sha512-LVirhuwMPOwATIDwlhGZt7C1BtrKp2+HJ7pALQcbC4+eHYyminniZEAzYjf0/EnjXtDj0SL3jnnBBvmpIJiWDQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-3.0.4.tgz",
+      "integrity": "sha512-JG6y6yWPDUBoJuWP7auwMTZf9SJN9d2e7y/ZbVvluQBZC+WvhLq1Z2cjWCjA21Y2FJxWeI27leBjWzyIsHtYUA==",
       "requires": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-cbor": "^8.0.0",
-        "@ucanto/core": "^3.0.1",
-        "@ucanto/interface": "^3.0.0",
-        "multiformats": "^10.0.0"
+        "@ucanto/core": "^3.0.2",
+        "@ucanto/interface": "^3.0.1",
+        "multiformats": "^10.0.2"
       }
     },
     "@w3up-api/services": {
@@ -20871,21 +16863,21 @@
       }
     },
     "@web3-storage/access": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@web3-storage/access/-/access-4.0.2.tgz",
-      "integrity": "sha512-Y81KX4ZQqkLRHKdX7mvxXw8ZvHnF399NFO1K0MTMcMf6kkDmGExGctsshbRGFGeByzBR/IS5FR57k7AZgQKEXg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@web3-storage/access/-/access-5.0.1.tgz",
+      "integrity": "sha512-s4UuPjwJCIk+dXzGqLTJkUHxF0KVPhnZcWdQavoA+MSr6QCMFbz2ZAz5o1XQWOYMYj02p1c5Gqc8bF/pBCpwEg==",
       "requires": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-ucan": "^2.0.1",
         "@noble/ed25519": "^1.7.1",
         "@types/ws": "^8.5.3",
-        "@ucanto/client": "^3.0.1",
-        "@ucanto/core": "^3.0.1",
-        "@ucanto/interface": "^3.0.0",
-        "@ucanto/principal": "^3.0.0",
-        "@ucanto/server": "^3.0.1",
-        "@ucanto/transport": "^3.0.1",
-        "@ucanto/validator": "^3.0.1",
+        "@ucanto/client": "^3.0.2",
+        "@ucanto/core": "^3.0.2",
+        "@ucanto/interface": "^3.0.1",
+        "@ucanto/principal": "^3.0.1",
+        "@ucanto/server": "^3.0.4",
+        "@ucanto/transport": "^3.0.2",
+        "@ucanto/validator": "^3.0.4",
         "@web-std/fetch": "^4.1.0",
         "bigint-mod-arith": "^3.1.2",
         "conf": "^10.1.2",
@@ -21004,9 +16996,9 @@
       }
     },
     "ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -21643,9 +17635,9 @@
       "integrity": "sha512-XAlt1IaQg9SRpuKPAhW1I1/E9Q63bPI/O+W5dcGniDwTJSbAUVZsH80XxeuADBCD2eIWEUlKOFfLmzhXZqt9tA=="
     },
     "aws-sdk": {
-      "version": "2.1252.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1252.0.tgz",
-      "integrity": "sha512-ayBNGAPhCm/tyWNki24cwPgI8DUm/suKTh2YDB6SrgeROyHJHMTXpj1dVaYXrBrZjRN7erVi5g7pkaxzCt/28A==",
+      "version": "2.1255.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1255.0.tgz",
+      "integrity": "sha512-S3oPXrBVOWquVL1bzH79bz88PgF4GqLcUbIph5yJ+pWW0OKNWGWKW1PDwtWi6ma+8mKXJ1gGKgy6R2hD57AsLw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -21949,9 +17941,9 @@
       }
     },
     "cborg": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.5.tgz",
-      "integrity": "sha512-fLBv8wmqtlXqy1Yu+pHzevAIkW6k2K0ZtMujNzWphLsA34vzzg9BHn+5GmZqOJkSA9V7EMKsWrf6K976c1QMjQ=="
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.6.tgz",
+      "integrity": "sha512-XmiD+NWTk9xg31d8MdXgW46bSZd95ELllxjbjdWGyHAtpTw+cf8iG3NibWgTWRnfWfxtcihVa5Pm0gchHiO3JQ=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -22023,9 +18015,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.6.1.tgz",
+      "integrity": "sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==",
       "dev": true
     },
     "ci-parallel-vars": {
@@ -22297,9 +18289,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.156",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.156.tgz",
-      "integrity": "sha512-BTZ3Kyt++/YFlph/ioqbDhzSKVMqHRHvc99FxU4b705ZP6s2IkDxMLCMinC70USMTJWFbO1p02Egux7sk4q07A==",
+      "version": "10.1.161",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.161.tgz",
+      "integrity": "sha512-+g6J5m6iAdrflfdbKlL1+5/RNyPvOmI+Quua/q85Ak65XuvrGGOTujAXcbQxYGNhwWJj4TCje6SsrJMcVpLfNQ==",
       "dev": true
     },
     "content-disposition": {
@@ -23696,13 +19688,28 @@
       "dev": true
     },
     "fast-jwt": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/fast-jwt/-/fast-jwt-1.7.1.tgz",
-      "integrity": "sha512-HdDR/k2d3qgUHDVwyhzYdHG/EK+IGhDGZFNidlSvCpVIhWMce8UYXUjx8hWEDhvOA032qoCtO1f/d/VcuzWhzA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/fast-jwt/-/fast-jwt-1.7.2.tgz",
+      "integrity": "sha512-OEInypGXJhtURzq9GbFM5KaALUu9+4IV3kJEbWPuqOBN5JBe7A51Tx0CaQYHGC9GNfZnr5npA0lCIMaWiZmz/A==",
       "requires": {
         "asn1.js": "^5.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
         "mnemonist": "^0.39.0"
+      },
+      "dependencies": {
+        "mnemonist": {
+          "version": "0.39.5",
+          "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.5.tgz",
+          "integrity": "sha512-FPUtkhtJ0efmEFGpU14x7jGbTB+s18LrzRL2KgoWz9YvcY3cPomz8tih01GbHwnGk/OmkOKfqd/RAQoc8Lm7DQ==",
+          "requires": {
+            "obliterator": "^2.0.1"
+          }
+        },
+        "obliterator": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+          "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
+        }
       }
     },
     "fast-levenshtein": {
@@ -23712,9 +19719,12 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
-      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "requires": {
+        "strnum": "^1.0.5"
+      }
     },
     "fastq": {
       "version": "1.13.0",
@@ -25448,11 +21458,11 @@
       "dev": true
     },
     "mnemonist": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.5.tgz",
-      "integrity": "sha512-FPUtkhtJ0efmEFGpU14x7jGbTB+s18LrzRL2KgoWz9YvcY3cPomz8tih01GbHwnGk/OmkOKfqd/RAQoc8Lm7DQ==",
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
       "requires": {
-        "obliterator": "^2.0.1"
+        "obliterator": "^1.6.1"
       }
     },
     "mrmime": {
@@ -25685,9 +21695,9 @@
       }
     },
     "obliterator": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
-      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
     },
     "oidc-token-hash": {
       "version": "5.0.1",
@@ -27377,9 +23387,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true
     },
     "uint8arrays": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "devDependencies": {
     "@ipld/dag-ucan": "^2.0.1",
-    "@serverless-stack/cli": "^1.17.1",
-    "@serverless-stack/resources": "^1.17.1",
+    "@serverless-stack/cli": "^1.18.0",
+    "@serverless-stack/resources": "^1.18.0",
     "@tsconfig/node16": "^1.0.3",
     "@types/aws-lambda": "^8.10.108",
     "ava": "^4.3.3",
@@ -24,18 +24,18 @@
     "lint-staged": "^13.0.3",
     "nanoid": "^4.0.0",
     "testcontainers": "^8.13.0",
-    "typescript": "^4.8.4"
+    "typescript": "^4.9.3"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.208.0",
-    "@aws-sdk/client-s3": "^3.209.0",
-    "@aws-sdk/util-dynamodb": "^3.208.0",
-    "@serverless-stack/node": "^1.17.1",
+    "@aws-sdk/client-dynamodb": "^3.211.0",
+    "@aws-sdk/client-s3": "^3.211.0",
+    "@aws-sdk/util-dynamodb": "^3.211.0",
+    "@serverless-stack/node": "^1.18.0",
     "@ucanto/interface": "^3.0.1",
-    "@ucanto/principal": "^3.0.0",
-    "@ucanto/server": "^3.0.1",
-    "@ucanto/transport": "^3.0.1",
-    "@web3-storage/access": "^4.0.2",
+    "@ucanto/principal": "^3.0.1",
+    "@ucanto/server": "^3.0.4",
+    "@ucanto/transport": "^3.0.2",
+    "@web3-storage/access": "^5.0.1",
     "@web3-storage/sigv4": "^1.0.2",
     "multiformats": "^10.0.2"
   },


### PR DESCRIPTION
This PR updates deps, most notably: `"@web3-storage/access": "^5.0.1"` which makes `store/add` link and size required, as well as fixes types inference 