### PR TITLE
feat: use ucanto client for store tests

### DIFF
--- a/api/test/service/store.test.js
+++ b/api/test/service/store.test.js
@@ -323,7 +323,6 @@ test('store list returns items previously stored by the user', async (t) => {
   links.reverse()
   let i = 0
   for (const entry of storeList.results) {
-    // TODO: what is `origin` for
     t.like(entry, { payloadCID: links[i].toString(), size: 5, origin: '' })
     i++
   }


### PR DESCRIPTION
Our tests get pretty neat using the uncanto client to invoke things.

Also clears up some naming of the various principles so it's easier to figure out who is doing what to whom.

Aims to show off in tests what our normal flow should look like when folks delegate from a space to their agent first, and then invoke things on the space as the agent with the proof of delegation.

As suggested by @alanshaw in https://github.com/web3-storage/upload-api/pull/14/files#r1023905697

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>