### PR TITLE
feat: upload star handlers

### DIFF
--- a/api/functions/ucan-invocation-router.js
+++ b/api/functions/ucan-invocation-router.js
@@ -6,6 +6,7 @@ import getServiceDid from '../authority.js'
 import { createSigner } from '../signer.js'
 import { createCarStore } from '../buckets/car-store.js'
 import { createStoreTable } from '../tables/store.js'
+import { createUploadTable } from '../tables/upload.js'
 import { createServiceRouter } from '../service/index.js'
 
 const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || ''
@@ -25,6 +26,7 @@ async function ucanInvocationRouter (request) {
   const {
     STORE_TABLE_NAME: storeTableName = '',
     STORE_BUCKET_NAME: storeBucketName = '',
+    UPLOAD_TABLE_NAME: uploadTableName = '',
     // set for testing
     DYNAMO_DB_ENDPOINT: dbEndpoint
   } = process.env
@@ -40,6 +42,9 @@ async function ucanInvocationRouter (request) {
       endpoint: dbEndpoint
     }),
     carStoreBucket: createCarStore(AWS_REGION, storeBucketName),
+    uploadTable: createUploadTable(AWS_REGION, uploadTableName, {
+      endpoint: dbEndpoint
+    }),
     signer: createSigner({
       region: AWS_REGION,
       secretAccessKey: AWS_SECRET_ACCESS_KEY,

--- a/api/package.json
+++ b/api/package.json
@@ -13,14 +13,16 @@
     "@ucanto/principal": "^3.0.1",
     "@ucanto/server": "^3.0.4",
     "@ucanto/transport": "^3.0.2",
-    "@web3-storage/access": "^5.0.1",
+    "@web3-storage/access": "^5.0.2",
     "@web3-storage/sigv4": "^1.0.2",
     "multiformats": "^10.0.2"
   },
   "devDependencies": {
+    "@ipld/car": "^5.0.1",
     "@ipld/dag-ucan": "^2.0.1",
     "@types/aws-lambda": "^8.10.108",
     "@ucanto/core": "^3.0.2",
+    "@web-std/blob": "3.0.4",
     "ava": "^4.3.3",
     "nanoid": "^4.0.0",
     "testcontainers": "^8.13.0"

--- a/api/service/index.js
+++ b/api/service/index.js
@@ -1,4 +1,5 @@
 import { createStoreService } from './store/index.js'
+import { createUploadService } from './upload/index.js'
 
 /**
  * @param {import('./types').UcantoServerContext} context
@@ -7,6 +8,6 @@ import { createStoreService } from './store/index.js'
 export function createServiceRouter (context) {
   return {
     store: createStoreService(context),
-    // TODO: upload
+    upload: createUploadService(context)
   }
 }

--- a/api/service/types.ts
+++ b/api/service/types.ts
@@ -3,11 +3,15 @@ import type { API, MalformedCapability } from '@ucanto/server'
 
 export interface StoreServiceContext {
   storeTable: StoreTable,
-  signer: Signer
   carStoreBucket: CarStoreBucket,
+  signer: Signer
 }
 
-export interface UcantoServerContext extends StoreServiceContext {}
+export interface UploadServiceContext {
+  uploadTable: UploadTable
+}
+
+export interface UcantoServerContext extends StoreServiceContext, UploadServiceContext {}
 
 export interface CarStoreBucket {
   has: (key: string) => Promise<boolean>
@@ -18,6 +22,13 @@ export interface StoreTable {
   insert: (item: StoreItemInput) => Promise<StoreItemOutput>
   remove: (uploaderDID: string, payloadCID: string) => Promise<void>
   list: (uploaderDID: string) => Promise<ListResponse<StoreListResult>>
+}
+
+export interface UploadTable {
+  exists: (uploaderDID: string, dataCID: string) => Promise<boolean>
+  insert: (uploaderDID: string, item: UploadItemInput) => Promise<UploadItemOutput[]>
+  remove: (uploaderDID: string, dataCID: string) => Promise<void>
+  list: (uploaderDID: string) => Promise<ListResponse<UploadItemOutput>>
 }
 
 export interface Signer {
@@ -67,4 +78,16 @@ export interface ListResponse<R> {
   cursorID?: string,
   pageSize: number,
   results: R[]
+}
+
+export interface UploadItemInput {
+  dataCID: string,
+  carCIDs: string[]
+}
+
+export interface UploadItemOutput {
+  uploaderDID: string,
+  dataCID: string,
+  carCID: string,
+  uploadedAt: string,
 }

--- a/api/service/upload/add.js
+++ b/api/service/upload/add.js
@@ -1,0 +1,27 @@
+import * as Server from '@ucanto/server'
+import * as Upload from '@web3-storage/access/capabilities/upload'
+
+/**
+ * @param {import('../types').UploadServiceContext} context
+ */
+export function uploadAddProvider(context) {
+  return Server.provide(
+    Upload.add,
+    async ({ capability, invocation }) => {
+      const { root, shards } = capability.nb
+
+      // Only use capability account for now to check if account is registered.
+      // This must change to access account/info!!
+      // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
+      const account = capability.with
+
+      const res = await context.uploadTable.insert(account, {
+        dataCID: root.toString(),
+        carCIDs: shards?.map(s => s.toString()) || []
+      })
+
+      // TODO: write mapping to DUDEWHERE
+
+      return res
+  })
+}

--- a/api/service/upload/index.js
+++ b/api/service/upload/index.js
@@ -1,0 +1,14 @@
+import { uploadAddProvider } from './add.js'
+import { uploadListProvider } from './list.js'
+import { uploadRemoveProvider } from './remove.js'
+
+/**
+ * @param {import('../types').UploadServiceContext} context
+ */
+ export function createUploadService (context) {
+  return {
+    add: uploadAddProvider(context),
+    list: uploadListProvider(context),
+    remove: uploadRemoveProvider(context)
+  }
+}

--- a/api/service/upload/list.js
+++ b/api/service/upload/list.js
@@ -1,0 +1,20 @@
+import * as Server from '@ucanto/server'
+import * as Upload from '@web3-storage/access/capabilities/upload'
+
+/**
+ * @param {import('../types').UploadServiceContext} context
+ */
+export function uploadListProvider(context) {
+  return Server.provide(
+    Upload.list,
+    async ({ capability }) => {
+      // Only use capability account for now to check if account is registered.
+      // This must change to access account/info!!
+      // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
+      const account = capability.with
+
+      // TODO: Page, Size
+
+      return await context.uploadTable.list(account)
+  })
+}

--- a/api/service/upload/remove.js
+++ b/api/service/upload/remove.js
@@ -1,0 +1,20 @@
+import * as Server from '@ucanto/server'
+import * as Upload from '@web3-storage/access/capabilities/upload'
+
+/**
+ * @param {import('../types').UploadServiceContext} context
+ */
+export function uploadRemoveProvider(context) {
+  return Server.provide(
+    Upload.remove,
+    async ({ capability }) => {
+      const { root } = capability.nb
+
+      // Only use capability account for now to check if account is registered.
+      // This must change to access account/info!!
+      // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
+      const account = capability.with
+
+      await context.uploadTable.remove(account, root.toString())
+  })
+}

--- a/api/tables/upload.js
+++ b/api/tables/upload.js
@@ -1,0 +1,169 @@
+import {
+  DynamoDBClient,
+  BatchWriteItemCommand,
+  GetItemCommand,
+  QueryCommand
+} from '@aws-sdk/client-dynamodb'
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
+
+// https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-dynamodb/classes/batchwriteitemcommand.html
+export const BATCH_MAX_SAFE_LIMIT = 25
+
+/**
+ * Abstraction layer to handle operations on Upload Table.
+ *
+ * @param {string} region
+ * @param {string} tableName
+ * @param {object} [options]
+ * @param {string} [options.endpoint]
+ * @returns {import('../service/types').UploadTable}
+ */
+export function createUploadTable (region, tableName, options = {}) {
+  const dynamoDb = new DynamoDBClient({
+    region,
+    endpoint: options.endpoint
+  })
+
+  return {
+    /**
+     * Check if the given data CID is bound to the uploader DID
+     *
+     * @param {string} uploaderDID
+     * @param {string} dataCID
+     */
+     exists: async (uploaderDID, dataCID) => {
+      const cmd = new GetItemCommand({
+        TableName: tableName,
+        Key: marshall({
+          uploaderDID,
+          dataCID,
+        }),
+        AttributesToGet: ['uploaderDID'],
+      })
+  
+      try {
+        const response = await dynamoDb.send(cmd)
+        return response?.Item !== undefined
+      } catch {
+        return false
+      }
+    },
+    /**
+     * Link an upload to an account
+     *
+     * @param {string} uploaderDID
+     * @param {import('../service/types').UploadItemInput} item
+     */
+    insert: async (uploaderDID, { dataCID, carCIDs }) => {
+      /** @type {import('../service/types').UploadItemOutput[]} */
+      const items = []
+      const batchItems = []
+
+      // Create returning array and array to batch
+      for (const carCID of carCIDs) {
+        const item = {
+          uploaderDID,
+          dataCID,
+          carCID,
+          uploadedAt: new Date().toISOString(),
+        }
+
+        items.push(item)
+        batchItems.push({
+          ...item,
+          // add sk property for Dynamo Key uniqueness
+          sk: `${item.dataCID}#${item.carCID}`
+        })
+      }
+
+      // Batch writes with max safe limit
+      while (batchItems.length > 0) {
+        const currentBatchItems = batchItems.splice(0, BATCH_MAX_SAFE_LIMIT)
+        const cmd = new BatchWriteItemCommand({
+          RequestItems: { [tableName]: currentBatchItems.map(item => ({
+            PutRequest: {
+              Item: marshall(item)
+            }
+          }))},
+        })
+        await dynamoDb.send(cmd)
+      }
+      
+      return items
+    },
+    /**
+     * Remove an upload from an account
+     *
+     * @param {string} uploaderDID
+     * @param {string} dataCID
+     */
+    remove:  async (uploaderDID, dataCID) => {
+      let lastEvaluatedKey
+      // Iterate through all carCIDs mapped to given uploaderDID
+      do {
+        // Get first batch of items to remove
+        const queryCommand = new QueryCommand({
+          TableName: tableName,
+          Limit: BATCH_MAX_SAFE_LIMIT,
+          ExpressionAttributeValues: {
+            ':u': { S: uploaderDID },
+            ':d': { S: dataCID }
+          },  
+          KeyConditionExpression: 'uploaderDID = :u',
+          FilterExpression: 'contains (dataCID, :d)',
+          ProjectionExpression: 'uploaderDID, sk'
+        })
+        const queryResponse = await dynamoDb.send(queryCommand)
+        // Update cursor if existing
+        lastEvaluatedKey = queryResponse.LastEvaluatedKey
+
+        const items = queryResponse.Items?.map(i => unmarshall(i)) || []
+        if (items.length === 0) {
+          break
+        }
+
+        // Batch remove set
+        const batchCmd = new BatchWriteItemCommand({
+          RequestItems: { [tableName]: items.map(item => ({
+            DeleteRequest: {
+              Key: marshall(item)
+            }
+          }))},
+        })
+      
+        await dynamoDb.send(batchCmd)
+      } while (lastEvaluatedKey)
+    },
+    /**
+     * List all CARs bound to an account
+     *
+     * @param {string} uploaderDID
+     * @param {import('../service/types').ListOptions} [options]
+     */
+    list:  async (uploaderDID, options = {}) => {
+      const cmd = new QueryCommand({
+        TableName: tableName,
+        Limit: options.pageSize || 20,
+        KeyConditions: {
+          uploaderDID: {
+            ComparisonOperator: 'EQ',
+            AttributeValueList: [{ S: uploaderDID }],
+          },
+        },
+        AttributesToGet: ['dataCID', 'carCID', 'uploadedAt'],
+      })
+      const response = await dynamoDb.send(cmd)
+
+      /** @type {import('../service/types').UploadItemOutput[]} */
+      // @ts-expect-error
+      const results = response.Items?.map(i => unmarshall(i)) || []
+
+      // TODO: cursor integrate with capabilities
+
+      return {
+        pageSize: results.length,
+        results
+      }
+    },
+  }
+}

--- a/api/tables/upload.js
+++ b/api/tables/upload.js
@@ -55,26 +55,21 @@ export function createUploadTable (region, tableName, options = {}) {
      * @param {import('../service/types').UploadItemInput} item
      */
     insert: async (uploaderDID, { dataCID, carCIDs }) => {
+      const uploadedAt = new Date().toISOString()
+
       /** @type {import('../service/types').UploadItemOutput[]} */
-      const items = []
-      const batchItems = []
-
-      // Create returning array and array to batch
-      for (const carCID of carCIDs) {
-        const item = {
-          uploaderDID,
-          dataCID,
-          carCID,
-          uploadedAt: new Date().toISOString(),
-        }
-
-        items.push(item)
-        batchItems.push({
-          ...item,
-          // add sk property for Dynamo Key uniqueness
-          sk: `${item.dataCID}#${item.carCID}`
-        })
-      }
+      const items = carCIDs.map(carCID => ({
+        uploaderDID,
+        dataCID,
+        carCID,
+        uploadedAt
+      }))
+      // items formatted for dynamodb
+      const batchItems = items.map(item => ({
+        ...item,
+        // add sk property for Dynamo Key uniqueness
+        sk: `${item.dataCID}#${item.carCID}`
+      }))
 
       // Batch writes with max safe limit
       while (batchItems.length > 0) {

--- a/api/test/fixtures.js
+++ b/api/test/fixtures.js
@@ -1,6 +1,0 @@
-import * as ed25519 from '@ucanto/principal/ed25519'
-
-/** did:key:z6Mkqa4oY9Z5Pf5tUcjLHLUsDjKwMC95HGXdE1j22jkbhz6r */
-export const alice = ed25519.parse(
-  'MgCZT5vOnYZoVAeyjnzuJIVY9J4LNtJ+f8Js0cTPuKUpFne0BVEDJjEu6quFIU8yp91/TY/+MYK8GvlKoTDnqOCovCVM='
-)

--- a/api/test/helpers/context.js
+++ b/api/test/helpers/context.js
@@ -1,7 +1,7 @@
 import anyTest from 'ava'
 
 /**
- * @typedef {object} StoreContext
+ * @typedef {object} UcantoServerContext
  * @property {string} dbEndpoint
  * @property {string} tableName
  * @property {string} region
@@ -10,7 +10,7 @@ import anyTest from 'ava'
  * @property {import('@aws-sdk/client-s3').ServiceInputTypes} s3ClientOpts
  * @property {import('@ucanto/principal/ed25519').EdSigner} serviceDid
  * 
- * @typedef {import("ava").TestFn<Awaited<ReturnType<StoreContext>>>} TestStoreFn
+ * @typedef {import("ava").TestFn<Awaited<ReturnType<UcantoServerContext>>>} TestStoreFn
  */
 
 // eslint-disable-next-line unicorn/prefer-export-from

--- a/api/test/helpers/random.js
+++ b/api/test/helpers/random.js
@@ -1,0 +1,41 @@
+import { webcrypto } from 'crypto'
+import { Blob } from '@web-std/blob'
+
+import { CarWriter } from '@ipld/car'
+import { CID } from 'multiformats/cid'
+import * as raw from 'multiformats/codecs/raw'
+import { sha256 } from 'multiformats/hashes/sha2'
+import * as CAR from '@ucanto/transport/car'
+
+/** @param {number} size */
+export async function randomBytes(size) {
+  const bytes = new Uint8Array(size)
+  while (size) {
+    const chunk = new Uint8Array(Math.min(size, 65_536))
+    webcrypto.getRandomValues(chunk)
+
+    size -= bytes.length
+    bytes.set(chunk, size)
+  }
+  return bytes
+}
+
+/** @param {number} size */
+export async function randomCAR(size) {
+  const bytes = await randomBytes(size)
+  const hash = await sha256.digest(bytes)
+  const root = CID.create(1, raw.code, hash)
+
+  const { writer, out } = CarWriter.create(root)
+  writer.put({ cid: root, bytes })
+  writer.close()
+
+  const chunks = []
+  for await (const chunk of out) {
+    chunks.push(chunk)
+  }
+  const blob = new Blob(chunks)
+  const cid = await CAR.codec.link(new Uint8Array(await blob.arrayBuffer()))
+
+  return Object.assign(blob, { cid, roots: [root] })
+}

--- a/api/test/helpers/ucanto.js
+++ b/api/test/helpers/ucanto.js
@@ -1,0 +1,58 @@
+import * as UcantoClient from '@ucanto/client'
+import { CAR, CBOR } from '@ucanto/transport'
+import * as Signer from '@ucanto/principal/ed25519'
+
+import { createUcantoServer } from '../../functions/ucan-invocation-router.js'
+import { createCarStore } from '../../buckets/car-store.js'
+import { createStoreTable } from '../../tables/store.js'
+import { createUploadTable } from '../../tables/upload.js'
+import { createSigner } from '../../signer.js'
+
+import { getSigningOptions } from '../utils.js'
+
+/**
+ * @param {any} ctx
+ */
+export function createTestingUcantoServer(ctx) {
+ return createUcantoServer({
+   storeTable: createStoreTable(ctx.region, ctx.tableName, {
+     endpoint: ctx.dbEndpoint
+   }),
+   uploadTable: createUploadTable(ctx.region, ctx.tableName, {
+     endpoint: ctx.dbEndpoint
+   }),
+   carStoreBucket: createCarStore(ctx.region, ctx.bucketName, { ...ctx.s3ClientOpts }),
+   signer: createSigner(getSigningOptions(ctx))
+ })
+}
+
+/**
+ * @param {import('@ucanto/principal/ed25519').EdSigner} service 
+ * @param {any} context 
+ * @returns 
+ */
+export async function getClientConnection (service, context) {
+  return UcantoClient.connect({
+    id: service,
+    encoder: CAR,
+    decoder: CBOR,
+    channel: await createTestingUcantoServer(context),
+  })
+}
+
+/**
+ * @param {import("@ucanto/principal/dist/src/ed25519/type.js").EdSigner<"key">} audience
+ */
+export async function createSpace (audience) {
+  const space = await Signer.generate()
+  const spaceDid = space.did()
+
+  return {
+    proof: await UcantoClient.delegate({
+      issuer: space,
+      audience,
+      capabilities: [{ can: '*', with: spaceDid }]
+    }),
+    spaceDid
+  }
+}

--- a/api/test/service/store.test.js
+++ b/api/test/service/store.test.js
@@ -3,16 +3,12 @@ import { CreateTableCommand, GetItemCommand } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { PutObjectCommand } from '@aws-sdk/client-s3'
 import * as Signer from '@ucanto/principal/ed25519'
-import { CAR, CBOR } from '@ucanto/transport'
-import * as UcantoClient from '@ucanto/client'
+import { CAR } from '@ucanto/transport'
 import * as StoreCapabilities from '@web3-storage/access/capabilities/store'
-import getServiceDid from '../../authority.js'
-import { createUcantoServer } from '../../functions/ucan-invocation-router.js'
-import { createCarStore } from '../../buckets/car-store.js'
-import { createStoreTable } from '../../tables/store.js'
-import { createSigner } from '../../signer.js'
 import { base64pad } from 'multiformats/bases/base64'
-import { createS3, createBucket, createDynamodDb, getSigningOptions } from '../utils.js'
+import getServiceDid from '../../authority.js'
+import { getClientConnection, createSpace } from '../helpers/ucanto.js'
+import { createS3, createBucket, createDynamodDb } from '../utils.js'
 
 test.beforeEach(async t => {
   const region = 'us-west-2'
@@ -39,32 +35,20 @@ test.beforeEach(async t => {
   t.context.serviceDid = await getServiceDid()
 })
 
-test('store add returns signed url for uploading', async (t) => {
+test('store/add returns signed url for uploading', async (t) => {
   const uploadService = t.context.serviceDid
   const alice = await Signer.generate()
-  const space = await Signer.generate()
+  const { proof, spaceDid } = await createSpace(alice)
+  const connection = await getClientConnection(uploadService, t.context)
+
   const data = new Uint8Array([11, 22, 34, 44, 55])
   const link = await CAR.codec.link(data)
-
-  const connection = UcantoClient.connect({
-    id: uploadService,
-    encoder: CAR,
-    decoder: CBOR,
-    channel: await createStoreUcantoServer(t.context),
-  })
-
-  // alice may do anything to this space
-  const proof = await UcantoClient.delegate({
-    issuer: space,
-    audience: alice,
-    capabilities: [{ can: '*', with: space.did() }]
-  })
 
   // invoke a store/add with proof
   const storeAdd = await StoreCapabilities.add.invoke({
     issuer: alice,
     audience: uploadService,
-    with: space.did(),
+    with: spaceDid,
     nb: { link, size: data.byteLength },
     proofs: [proof]
     // @ts-expect-error ʅʕ•ᴥ•ʔʃ
@@ -72,42 +56,30 @@ test('store add returns signed url for uploading', async (t) => {
 
   t.not(storeAdd.error, true, storeAdd.message)
   t.is(storeAdd.status, 'upload')
-  t.is(storeAdd.with, space.did())
+  t.is(storeAdd.with, spaceDid)
   t.deepEqual(storeAdd.link, link)
   t.is(new URL(storeAdd.url).pathname, `/${link}/${link}.car`)
   t.is(storeAdd.headers['x-amz-checksum-sha256'], base64pad.baseEncode(link.multihash.digest))
 
-  const item = await getItemFromStoreTable(t.context.dynamoClient, space, link)
+  const item = await getItemFromStoreTable(t.context.dynamoClient, spaceDid, link)
   t.truthy(item)
   t.is(typeof item?.uploadedAt, 'string')
   t.is(typeof item?.proof, 'string')
   t.is(typeof item?.uploaderDID, 'string')
   // TODO: this looks suspicious... why is uploaderDID not the issuer / alice who invoked the upload
-  t.is(item?.uploaderDID, space.did())
+  t.is(item?.uploaderDID, spaceDid)
   t.is(typeof item?.size, 'number')
   t.is(item?.size, data.byteLength)
 })
 
-test('store add returns done if already uploaded', async (t) => {
+test('store/add returns done if already uploaded', async (t) => {
   const uploadService = t.context.serviceDid
   const alice = await Signer.generate()
-  const space = await Signer.generate()
+  const { proof, spaceDid } = await createSpace(alice)
+  const connection = await getClientConnection(uploadService, t.context)
+
   const data = new Uint8Array([11, 22, 34, 44, 55])
   const link = await CAR.codec.link(data)
-
-  const connection = UcantoClient.connect({
-    id: uploadService,
-    encoder: CAR,
-    decoder: CBOR,
-    channel: await createStoreUcantoServer(t.context),
-  })
-
-  // alice may do anything to this space
-  const proof = await UcantoClient.delegate({
-    issuer: space,
-    audience: alice,
-    capabilities: [{ can: '*', with: space.did() }]
-  })
 
   // simulate an already stored CAR
   await t.context.s3Client.send(
@@ -121,52 +93,40 @@ test('store add returns done if already uploaded', async (t) => {
   const storeAdd = await StoreCapabilities.add.invoke({
     issuer: alice,
     audience: uploadService,
-    with: space.did(),
+    with: spaceDid,
     nb: { link, size: data.byteLength },
     proofs: [proof]
     // @ts-expect-error ʅʕ•ᴥ•ʔʃ
   }).execute(connection)
 
   t.is(storeAdd.status, 'done')
-  t.is(storeAdd.with, space.did())
+  t.is(storeAdd.with, spaceDid)
   t.deepEqual(storeAdd.link, link)
   t.falsy(storeAdd.url)
 
   // Even if done (CAR already exists in bucket), mapped to user if non existing
-  const item = await getItemFromStoreTable(t.context.dynamoClient, space, link)
+  const item = await getItemFromStoreTable(t.context.dynamoClient, spaceDid, link)
   t.is(typeof item?.uploadedAt, 'string')
   t.is(typeof item?.proof, 'string')
   t.is(typeof item?.uploaderDID, 'string')
-  t.is(item?.uploaderDID, space.did())
+  t.is(item?.uploaderDID, spaceDid)
   t.is(typeof item?.size, 'number')
   t.is(item?.size, data.byteLength)
 })
 
-test('store remove does not fail for non existent link', async (t) => {
+test('store/remove does not fail for non existent link', async (t) => {
   const uploadService = t.context.serviceDid
   const alice = await Signer.generate()
-  const space = await Signer.generate()
+  const { proof, spaceDid } = await createSpace(alice)
+  const connection = await getClientConnection(uploadService, t.context)
+
   const data = new Uint8Array([11, 22, 34, 44, 55])
   const link = await CAR.codec.link(data)
-
-  const connection = UcantoClient.connect({
-    id: uploadService,
-    encoder: CAR,
-    decoder: CBOR,
-    channel: await createStoreUcantoServer(t.context),
-  })
-
-  // alice may do anything to this space
-  const proof = await UcantoClient.delegate({
-    issuer: space,
-    audience: alice,
-    capabilities: [{ can: '*', with: space.did() }]
-  })
 
   const storeRemove = await StoreCapabilities.remove.invoke({
     issuer: alice,
     audience: uploadService,
-    with: space.did(),
+    with: spaceDid,
     nb: { link },
     proofs: [proof]
     // @ts-expect-error ʅʕ•ᴥ•ʔʃ
@@ -178,7 +138,7 @@ test('store remove does not fail for non existent link', async (t) => {
   const storeRemove2 = await StoreCapabilities.remove.invoke({
     issuer: alice,
     audience: uploadService,
-    with: space.did(),
+    with: spaceDid,
     nb: { link },
     proofs: [proof]
     // @ts-expect-error ʅʕ•ᴥ•ʔʃ
@@ -188,35 +148,23 @@ test('store remove does not fail for non existent link', async (t) => {
   t.falsy(storeRemove2)
 })
 
-test('store remove invocation removes car bound to issuer from store table', async (t) => {
+test('store/remove removes car bound to issuer from store table', async (t) => {
   const uploadService = t.context.serviceDid
   const alice = await Signer.generate()
-  const space = await Signer.generate()
+  const { proof, spaceDid } = await createSpace(alice)
+  const connection = await getClientConnection(uploadService, t.context)
+
   const data = new Uint8Array([11, 22, 34, 44, 55])
   const link = await CAR.codec.link(data)
 
-  const connection = UcantoClient.connect({
-    id: uploadService,
-    encoder: CAR,
-    decoder: CBOR,
-    channel: await createStoreUcantoServer(t.context),
-  })
-
-  // alice may do anything to this space
-  const proof = await UcantoClient.delegate({
-    issuer: space,
-    audience: alice,
-    capabilities: [{ can: '*', with: space.did() }]
-  })
-
   // Validate Store Table content does not exist before add
-  const dynamoItemBeforeAdd = await getItemFromStoreTable(t.context.dynamoClient, space, link)
+  const dynamoItemBeforeAdd = await getItemFromStoreTable(t.context.dynamoClient, spaceDid, link)
   t.falsy(dynamoItemBeforeAdd)
 
   const storeAdd = await StoreCapabilities.add.invoke({
     issuer: alice,
     audience: uploadService,
-    with: space.did(),
+    with: spaceDid,
     nb: { link, size: data.byteLength },
     proofs: [proof]
     // @ts-expect-error ʅʕ•ᴥ•ʔʃ
@@ -225,13 +173,13 @@ test('store remove invocation removes car bound to issuer from store table', asy
   t.is(storeAdd.status, 'upload')
 
   // Validate Store Table content exists after add
-  const dynamoItemAfterAdd = await getItemFromStoreTable(t.context.dynamoClient, space, link)
+  const dynamoItemAfterAdd = await getItemFromStoreTable(t.context.dynamoClient, spaceDid, link)
   t.truthy(dynamoItemAfterAdd)
 
   const storeRemove = await StoreCapabilities.remove.invoke({
     issuer: alice,
     audience: uploadService,
-    with: space.did(),
+    with: spaceDid,
     nb: { link },
     proofs: [proof]
     // @ts-expect-error ʅʕ•ᴥ•ʔʃ
@@ -240,33 +188,20 @@ test('store remove invocation removes car bound to issuer from store table', asy
   t.falsy(storeRemove)
 
   // Validate Store Table content does not exist after remove
-  const dynamoItemAfterRemove = await getItemFromStoreTable(t.context.dynamoClient, space, link)
+  const dynamoItemAfterRemove = await getItemFromStoreTable(t.context.dynamoClient, spaceDid, link)
   t.falsy(dynamoItemAfterRemove)
 })
 
-test('store list does not fail for empty list', async (t) => {
+test('store/list does not fail for empty list', async (t) => {
   const uploadService = t.context.serviceDid
   const alice = await Signer.generate()
-  const space = await Signer.generate()
-
-  const connection = UcantoClient.connect({
-    id: uploadService,
-    encoder: CAR,
-    decoder: CBOR,
-    channel: await createStoreUcantoServer(t.context),
-  })
-
-  // alice may do anything to this space
-  const proof = await UcantoClient.delegate({
-    issuer: space,
-    audience: alice,
-    capabilities: [{ can: '*', with: space.did() }]
-  })
+  const { proof, spaceDid } = await createSpace(alice)
+  const connection = await getClientConnection(uploadService, t.context)
   
   const storeList = await StoreCapabilities.list.invoke({
     issuer: alice,
     audience: uploadService,
-    with: space.did(),
+    with: spaceDid,
     proofs: [ proof ]
     // @ts-expect-error ʅʕ•ᴥ•ʔʃ
   }).execute(connection)
@@ -274,24 +209,11 @@ test('store list does not fail for empty list', async (t) => {
   t.like(storeList, { results: [], pageSize: 0 })
 })
 
-test('store list returns items previously stored by the user', async (t) => {
+test('store/list returns items previously stored by the user', async (t) => {
   const uploadService = t.context.serviceDid
   const alice = await Signer.generate()
-  const space = await Signer.generate()
-
-  const connection = UcantoClient.connect({
-    id: uploadService,
-    encoder: CAR,
-    decoder: CBOR,
-    channel: await createStoreUcantoServer(t.context),
-  })
-
-  // alice may do anything to this space
-  const proof = await UcantoClient.delegate({
-    issuer: space,
-    audience: alice,
-    capabilities: [{ can: '*', with: space.did() }]
-  })
+  const { proof, spaceDid } = await createSpace(alice)
+  const connection = await getClientConnection(uploadService, t.context)
 
   const data = [ new Uint8Array([11, 22, 34, 44, 55]), new Uint8Array([22, 34, 44, 55, 66]) ]
   const links = []
@@ -299,7 +221,7 @@ test('store list returns items previously stored by the user', async (t) => {
     const storeAdd = await StoreCapabilities.add.invoke({
       issuer: alice,
       audience: uploadService,
-      with: space.did(),
+      with: spaceDid,
       nb: { link: await CAR.codec.link(datum) , size: datum.byteLength },
       proofs: [proof]
       // @ts-expect-error ʅʕ•ᴥ•ʔʃ
@@ -312,7 +234,7 @@ test('store list returns items previously stored by the user', async (t) => {
   const storeList = await StoreCapabilities.list.invoke({
     issuer: alice,
     audience: uploadService,
-    with: space.did(),
+    with: spaceDid,
     proofs: [ proof ]
     // @ts-expect-error ʅʕ•ᴥ•ʔʃ
   }).execute(connection)
@@ -327,19 +249,6 @@ test('store list returns items previously stored by the user', async (t) => {
     i++
   }
 })
-
-/**
- * @param {any} ctx
- */
-function createStoreUcantoServer(ctx) {
-  return createUcantoServer({
-    storeTable: createStoreTable(ctx.region, ctx.tableName, {
-      endpoint: ctx.dbEndpoint
-    }),
-    carStoreBucket: createCarStore(ctx.region, ctx.bucketName, { ...ctx.s3ClientOpts }),
-    signer: createSigner(getSigningOptions(ctx))
-  })
-}
 
 /**
  * @param {import("@aws-sdk/client-dynamodb").DynamoDBClient} dynamo
@@ -365,14 +274,14 @@ async function createDynamoStoreTable(dynamo) {
 
 /**
  * @param {import("@aws-sdk/client-dynamodb").DynamoDBClient} dynamo
- * @param {import('@ucanto/principal/ed25519').EdSigner} did
+ * @param {`did:key:${string}`} spaceDid
  * @param {import('@ucanto/interface').Link<unknown, number, number, 0 | 1>} link
  */
-async function getItemFromStoreTable(dynamo, did, link) {
+async function getItemFromStoreTable(dynamo, spaceDid, link) {
   const params = {
     TableName: 'store',
     Key: marshall({
-      uploaderDID: did.did(),
+      uploaderDID: spaceDid,
       payloadCID: link.toString(),
     }),
     AttributesToGet: ['uploaderDID', 'proof', 'uploadedAt', 'size'],

--- a/api/test/service/upload.test.js
+++ b/api/test/service/upload.test.js
@@ -1,0 +1,367 @@
+import { testStore as test } from '../helpers/context.js'
+import { CreateTableCommand, QueryCommand } from '@aws-sdk/client-dynamodb'
+import { unmarshall } from '@aws-sdk/util-dynamodb'
+import * as Signer from '@ucanto/principal/ed25519'
+import * as UploadCapabilities from '@web3-storage/access/capabilities/upload'
+
+import getServiceDid from '../../authority.js'
+import { BATCH_MAX_SAFE_LIMIT } from '../../tables/upload.js'
+
+import { createDynamodDb } from '../utils.js'
+import { randomCAR } from '../helpers/random.js'
+import { getClientConnection, createSpace } from '../helpers/ucanto.js'
+
+test.beforeEach(async t => {
+  const region = 'us-west-2'
+  const tableName = 'upload'
+
+  // Dynamo DB
+  const {
+    client: dynamo,
+    endpoint: dbEndpoint
+  } = await createDynamodDb({ port: 8000, region })
+  await createDynamoUploadTable(dynamo)
+
+  t.context.dbEndpoint = dbEndpoint
+  t.context.dynamoClient = dynamo
+  t.context.tableName = tableName
+  t.context.region = region
+  t.context.serviceDid = await getServiceDid()
+})
+
+test('upload/add inserts into DB mapping between data CID and car CIDs', async (t) => {
+  const uploadService = t.context.serviceDid
+  const alice = await Signer.generate()
+  const { proof, spaceDid } = await createSpace(alice)
+  const connection = await getClientConnection(uploadService, t.context)
+
+  const car = await randomCAR(128)
+  const otherCar = await randomCAR(40)
+
+  // invoke a upload/add with proof
+  const root = car.roots[0]
+  const shards = [car.cid, otherCar.cid]
+
+  /** @type {import('../../service/types').UploadItemOutput[]} */
+  const uploadAdd = await UploadCapabilities.add.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: spaceDid,
+    nb: { root, shards },
+    proofs: [proof]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+
+  // @ts-expect-error error is added by ucanto if it fails
+  t.not(uploadAdd.error, true, uploadAdd.message)
+  t.is(uploadAdd.length, shards.length)
+
+  // Validate shards result
+  for (const shard of shards) {
+    const shardResult = uploadAdd.find((s) => s.carCID === shard.toString())
+    t.is(shardResult?.dataCID, root.toString())
+    t.is(shardResult?.uploaderDID, spaceDid)
+    t.truthy(shardResult?.uploadedAt)
+  }
+
+  // Validate DB
+  const dbItems = await getSpaceItems(t.context.dynamoClient, spaceDid)
+  t.is(dbItems.length, shards.length)
+
+  // Validate shards result
+  for (const shard of shards) {
+    const shardResult = dbItems.find((s) => s.carCID === shard.toString())
+    t.is(shardResult?.dataCID, root.toString())
+    t.truthy(shardResult?.uploadedAt)
+  }
+})
+
+// TODO: this is current behavior with optional nb.
+// We should look into this as a desired behavior
+test('upload/add does not fail with no shards provided', async (t) => {
+  const uploadService = t.context.serviceDid
+  const alice = await Signer.generate()
+  const { proof, spaceDid } = await createSpace(alice)
+  const connection = await getClientConnection(uploadService, t.context)
+
+  const car = await randomCAR(128)
+
+  // invoke a upload/add with proof
+  const root = car.roots[0]
+
+  /** @type {import('../../service/types').UploadItemOutput[]} */
+  const uploadAdd = await UploadCapabilities.add.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: spaceDid,
+    nb: { root },
+    proofs: [proof]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+
+  // @ts-expect-error error is added by ucanto if it fails
+  t.not(uploadAdd.error, true, uploadAdd.message)
+  t.is(uploadAdd.length, 0)
+
+  // Validate DB
+  const dbItems = await getSpaceItems(t.context.dynamoClient, spaceDid)
+  t.is(dbItems.length, 0)
+})
+
+test('upload/remove does not fail for non existent upload', async (t) => {
+  const uploadService = t.context.serviceDid
+  const alice = await Signer.generate()
+  const { proof, spaceDid } = await createSpace(alice)
+  const connection = await getClientConnection(uploadService, t.context)
+
+  const car = await randomCAR(128)
+
+  // invoke a upload/add with proof
+  const root = car.roots[0]
+
+  const uploadRemove = await UploadCapabilities.remove.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: spaceDid,
+    nb: { root },
+    proofs: [proof]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+
+  // expect no response for a remove
+  t.falsy(uploadRemove)
+})
+
+test('upload/remove removes all entries with data CID linked to space', async (t) => {
+  const uploadService = t.context.serviceDid
+  const alice = await Signer.generate()
+  const { proof: proofSpaceA, spaceDid: spaceDidA } = await createSpace(alice)
+  const { proof: proofSpaceB, spaceDid: spaceDidB } = await createSpace(alice)
+  const connection = await getClientConnection(uploadService, t.context)
+
+  const carA = await randomCAR(128)
+  const carB = await randomCAR(40)
+
+  // Invoke two upload/add for spaceA and one upload/add for spaceB
+
+  // Upload CarA to SpaceA
+  const uploadAddCarAToSpaceA = await UploadCapabilities.add.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: spaceDidA,
+    nb: { root: carA.roots[0], shards: [carA.cid, carB.cid] },
+    proofs: [proofSpaceA]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+  t.not(uploadAddCarAToSpaceA.error, true, uploadAddCarAToSpaceA.message)
+
+  // Upload CarB to SpaceA
+  const uploadAddCarBToSpaceA = await UploadCapabilities.add.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: spaceDidA,
+    nb: { root: carB.roots[0], shards: [carB.cid, carA.cid] },
+    proofs: [proofSpaceA]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+  t.not(uploadAddCarBToSpaceA.error, true, uploadAddCarBToSpaceA.message)
+
+  // Upload CarA to SpaceB
+  const uploadAddCarAToSpaceB = await UploadCapabilities.add.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: spaceDidB,
+    nb: { root: carA.roots[0], shards: [carA.cid, carB.cid] },
+    proofs: [proofSpaceB]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+  t.not(uploadAddCarAToSpaceB.error, true, uploadAddCarAToSpaceB.message)
+
+  // Remove CarA from SpaceA
+  await UploadCapabilities.remove.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: spaceDidA,
+    nb: { root: carA.roots[0] },
+    proofs: [proofSpaceA]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+
+  // Validate SpaceA has 0 items for CarA
+  const spaceAcarAItems = await getSpaceItemsFilteredByDataCID(t.context.dynamoClient, spaceDidA, carA.roots[0])
+  t.is(spaceAcarAItems.length, 0)
+
+  // Validate SpaceA has 2 items for CarB
+  const spaceAcarBItems = await getSpaceItemsFilteredByDataCID(t.context.dynamoClient, spaceDidA, carB.roots[0])
+  t.is(spaceAcarBItems.length, 2)
+
+  // Validate SpaceB has 2 items for CarA
+  const spaceBcarAItems = await getSpaceItemsFilteredByDataCID(t.context.dynamoClient, spaceDidB, carA.roots[0])
+  t.is(spaceBcarAItems.length, 2)
+})
+
+test('upload/remove removes all entries when larger than batch limit', async (t) => {
+  const uploadService = t.context.serviceDid
+  const alice = await Signer.generate()
+  const { proof, spaceDid } = await createSpace(alice)
+  const connection = await getClientConnection(uploadService, t.context)
+
+  // create upload with more shards than dynamo batch limit
+  const cars = await Promise.all(
+    Array.from({ length: BATCH_MAX_SAFE_LIMIT + 1 }).map(() => randomCAR(40))
+  )
+  const root = cars[0].roots[0]
+  const shards = cars.map(c => c.cid)
+
+  /** @type {import('../../service/types').UploadItemOutput[]} */
+  const uploadAdd = await UploadCapabilities.add.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: spaceDid,
+    nb: { root, shards },
+    proofs: [proof]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+
+  // @ts-expect-error error is added by ucanto if it fails
+  t.not(uploadAdd.error, true, uploadAdd.message)
+  t.is(uploadAdd.length, shards.length)
+
+  // Validate DB before remove
+  const dbItemsBefore = await getSpaceItems(t.context.dynamoClient, spaceDid)
+  t.is(dbItemsBefore.length, shards.length)
+
+  // Remove Car from Space
+  await UploadCapabilities.remove.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: spaceDid,
+    nb: { root },
+    proofs: [proof]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+
+  // Validate DB after remove
+  const dbItemsAfter = await getSpaceItems(t.context.dynamoClient, spaceDid)
+  t.is(dbItemsAfter.length, 0)
+})
+
+test('store/list does not fail for empty list', async (t) => {
+  const uploadService = t.context.serviceDid
+  const alice = await Signer.generate()
+  const { proof, spaceDid } = await createSpace(alice)
+  const connection = await getClientConnection(uploadService, t.context)
+  
+  const uploadList = await UploadCapabilities.list.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: spaceDid,
+    proofs: [ proof ]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+
+  t.like(uploadList, { results: [], pageSize: 0 })
+})
+
+test('store/list returns entries previously uploaded by the user', async (t) => {
+  const uploadService = t.context.serviceDid
+  const alice = await Signer.generate()
+  const { proof, spaceDid } = await createSpace(alice)
+  const connection = await getClientConnection(uploadService, t.context)
+
+  // invoke multiple upload/add with proof
+  const cars = [
+    await randomCAR(128),
+    await randomCAR(128)
+  ]
+
+  for (const car of cars) {
+    await UploadCapabilities.add.invoke({
+      issuer: alice,
+      audience: uploadService,
+      with: spaceDid,
+      nb: { root: car.roots[0], shards: [car.cid] },
+      proofs: [proof]
+      // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+    }).execute(connection)
+  }
+
+  /** @type {import('../../service/types').ListResponse<import('../../service/types').UploadItemOutput>} */
+  const uploadList = await UploadCapabilities.list.invoke({
+    issuer: alice,
+    audience: uploadService,
+    with: spaceDid,
+    proofs: [ proof ]
+    // @ts-expect-error ʅʕ•ᴥ•ʔʃ
+  }).execute(connection)
+
+  t.is(uploadList.pageSize, cars.length)
+
+  // Validate entries have given CARs
+  for (const entry of uploadList.results) {
+    t.truthy(cars.find(car => car.roots[0].toString() === entry.dataCID ))
+  }
+})
+
+/**
+ * @param {import("@aws-sdk/client-dynamodb").DynamoDBClient} dynamo
+ */
+ async function createDynamoUploadTable(dynamo) {
+  await dynamo.send(new CreateTableCommand({
+    TableName: 'upload',
+    AttributeDefinitions: [
+      { AttributeName: 'uploaderDID', AttributeType: 'S' },
+      { AttributeName: 'sk', AttributeType: 'S' }
+    ],
+    KeySchema: [
+      { AttributeName: 'uploaderDID', KeyType: 'HASH' },
+      { AttributeName: 'sk', KeyType: 'RANGE' },
+    ],
+    ProvisionedThroughput: {
+      ReadCapacityUnits: 1,
+      WriteCapacityUnits: 1
+    }
+  }))
+}
+
+/**
+ * @param {import("@aws-sdk/client-dynamodb").DynamoDBClient} dynamo
+ * @param {`did:key:${string}`} spaceDid
+ */
+ async function getSpaceItems(dynamo, spaceDid) {
+  const cmd = new QueryCommand({
+    TableName: 'upload',
+    Limit: 30,
+    ExpressionAttributeValues: {
+      ':u': { S: spaceDid },
+    },  
+    KeyConditionExpression: 'uploaderDID = :u',
+    ProjectionExpression: 'dataCID, carCID, uploadedAt'
+  })
+
+  const response = await dynamo.send(cmd)
+  return response.Items?.map(i => unmarshall(i)) || []
+}
+
+/**
+ * @param {import("@aws-sdk/client-dynamodb").DynamoDBClient} dynamo
+ * @param {`did:key:${string}`} spaceDid
+ * @param {import("multiformats").CID<unknown, 85, 18, 1>} dataCid
+ */
+ async function getSpaceItemsFilteredByDataCID(dynamo, spaceDid, dataCid) {
+  const cmd = new QueryCommand({
+    TableName: 'upload',
+    Limit: 30,
+    ExpressionAttributeValues: {
+      ':u': { S: spaceDid },
+      ':d': { S: dataCid.toString() }
+    },  
+    KeyConditionExpression: 'uploaderDID = :u',
+    FilterExpression: 'contains (dataCID, :d)',
+    ProjectionExpression: 'dataCID, carCID, uploadedAt'
+  })
+
+  const response = await dynamo.send(cmd)
+  return response.Items?.map(i => unmarshall(i)) || []
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,14 +34,16 @@
         "@ucanto/principal": "^3.0.1",
         "@ucanto/server": "^3.0.4",
         "@ucanto/transport": "^3.0.2",
-        "@web3-storage/access": "^5.0.1",
+        "@web3-storage/access": "^5.0.2",
         "@web3-storage/sigv4": "^1.0.2",
         "multiformats": "^10.0.2"
       },
       "devDependencies": {
+        "@ipld/car": "^5.0.1",
         "@ipld/dag-ucan": "^2.0.1",
         "@types/aws-lambda": "^8.10.108",
         "@ucanto/core": "^3.0.2",
+        "@web-std/blob": "3.0.4",
         "ava": "^4.3.3",
         "nanoid": "^4.0.0",
         "testcontainers": "^8.13.0"
@@ -6253,9 +6255,9 @@
       }
     },
     "node_modules/@web3-storage/access": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/access/-/access-5.0.1.tgz",
-      "integrity": "sha512-s4UuPjwJCIk+dXzGqLTJkUHxF0KVPhnZcWdQavoA+MSr6QCMFbz2ZAz5o1XQWOYMYj02p1c5Gqc8bF/pBCpwEg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@web3-storage/access/-/access-5.0.2.tgz",
+      "integrity": "sha512-EdrfJ+rLo3tn0dm6660LBTzzhabXglmEpJRtdU0A0S8jYp2kybhSHiRsLKymmPo8orHhEZNsiLWEO1ccoPSTNQ==",
       "dependencies": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-ucan": "^2.0.1",
@@ -20774,6 +20776,7 @@
         "@aws-sdk/client-dynamodb": "^3.211.0",
         "@aws-sdk/client-s3": "^3.211.0",
         "@aws-sdk/util-dynamodb": "^3.211.0",
+        "@ipld/car": "^5.0.1",
         "@ipld/dag-ucan": "^2.0.1",
         "@types/aws-lambda": "^8.10.108",
         "@ucanto/core": "^3.0.2",
@@ -20781,7 +20784,8 @@
         "@ucanto/principal": "^3.0.1",
         "@ucanto/server": "^3.0.4",
         "@ucanto/transport": "^3.0.2",
-        "@web3-storage/access": "^5.0.1",
+        "@web-std/blob": "3.0.4",
+        "@web3-storage/access": "^5.0.2",
         "@web3-storage/sigv4": "^1.0.2",
         "ava": "^4.3.3",
         "multiformats": "^10.0.2",
@@ -20838,9 +20842,9 @@
       }
     },
     "@web3-storage/access": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/access/-/access-5.0.1.tgz",
-      "integrity": "sha512-s4UuPjwJCIk+dXzGqLTJkUHxF0KVPhnZcWdQavoA+MSr6QCMFbz2ZAz5o1XQWOYMYj02p1c5Gqc8bF/pBCpwEg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@web3-storage/access/-/access-5.0.2.tgz",
+      "integrity": "sha512-EdrfJ+rLo3tn0dm6660LBTzzhabXglmEpJRtdU0A0S8jYp2kybhSHiRsLKymmPo8orHhEZNsiLWEO1ccoPSTNQ==",
       "requires": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-ucan": "^2.0.1",


### PR DESCRIPTION
This PR adds `upload/*` handlers as well as their tests.

It includes
- new Table resource with upload listing (follows same schema as w3up)
- uploadTable abstraction like storeTable
- update access to fix `upload/add` type inference
- random car helper function stolen from client tests
- updated `store` tests to use `createSpace` and `getClientConnection` helpers

Note that:
- pagination will be handled as follow up
- removes unused fixtures folder
- dynamoDB does not support deleting items without providing entire key.
  - Upload table key is `primaryIndex: { partitionKey: 'uploaderDID', sortKey: 'sk' }` to be unique. However, when `upload/remove` is triggered we receive `uploaderDID` and `dataCID` and have no way to get `sk` ('dataCID#carCID'). 
  - We need to perform an initial query to get items from DB, and then batch deleteRequests. It is also important mentioning that Dynamo brings more [fun to the table](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-dynamodb/classes/batchwriteitemcommand.html). Batch has some limitations, I am not worried with size but we might have more than 25 items to batch delete. So, we need to guarantee that batches bigger than it are not created, iterating in loop if more
  - Note: same applies for batch insert on `upload/add`

Still todo:
- [x] figure out remove

Closes #12 