### PR TITLE
feat: deploy to custom domain up.web3.storage

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -1,1 +1,5 @@
 # These variables are only available in your SST code.
+
+# uncomment to try out deploying the api under a custom domain.
+# the value should match a hosted zone configured in route53 that your aws account has access to.
+# HOSTED_ZONE=up.dag.haus

--- a/stacks/api-stack.js
+++ b/stacks/api-stack.js
@@ -4,7 +4,7 @@ import {
   Table
 } from '@serverless-stack/resources'
 
-import { getConfig } from './config.js'
+import { getConfig, getCustomDomain } from './config.js'
 
 /**
  * @param {import('@serverless-stack/resources').StackContext} properties
@@ -58,7 +58,10 @@ export function ApiStack({ stack }) {
     ...stackConfig.tableConfig,
   })
 
+  const customDomain = getCustomDomain(stack.stage, process.env.HOSTED_ZONE)
+
   const api = new Api(stack, 'http-gateway', {
+    customDomain,
     defaults: {
       function: {
         permissions: [storeTable, uploadTable, storeBucket],
@@ -76,5 +79,6 @@ export function ApiStack({ stack }) {
 
   stack.addOutputs({
     ApiEndpoint: api.url,
+    CustomDomain:  customDomain ? `https://${customDomain.domainName}` : 'Set HOSTED_ZONE in env to deploy to a custom domain'
   })
 }

--- a/stacks/config.js
+++ b/stacks/config.js
@@ -49,3 +49,21 @@ const stageConfigs = {
 export function getConfig(stage) {
   return stageConfigs[stage] || stageConfigs.dev
 }
+
+/**
+ * Return the custom domain config for http api
+ * 
+ * @param {string} stage
+ * @param {string | undefined} hostedZone
+ * @returns {{domainName: string, hostedZone: string} | undefined}
+ */
+export function getCustomDomain (stage, hostedZone) {
+  // return no custom domain config if hostedZone not set
+  if (!hostedZone) {
+    return 
+  }
+  /** @type Record<string,string> */
+  const domainMap = { prod: hostedZone }
+  const domainName = domainMap[stage] ?? `${stage}.${hostedZone}`
+  return { domainName, hostedZone }
+}


### PR DESCRIPTION
Adds custom domain config to api definition per https://docs.sst.dev/constructs/Api#customdomain

Adds `HOSTED_ZONE` env var. the value should match a hosted zone configured in route53 that your aws account has access to.

## TO DONE

- [x] Create hosted zone for `up.web3.storage` on route53
- [x] Add NS records to web3.storage zone on cloudflare to point `up.web3.storage` to route53
- [x] Update `HOSTED_ZONE=up.web3.storage` on seed.run

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>