### PR TITLE
fix: omit origin if empty on store list

### DIFF
--- a/api/tables/store.js
+++ b/api/tables/store.js
@@ -110,7 +110,15 @@ export function createStoreTable (region, tableName, options = {}) {
 
       /** @type {import('../service/types').StoreListResult[]} */
       // @ts-expect-error
-      const results = response.Items?.map(i => unmarshall(i)) || []
+      const results = response.Items?.map(i => {
+        const item = unmarshall(i)
+        // omit origin if empty
+        if (!item.origin) {
+          delete item.origin
+        }
+
+        return item
+      }) || []
 
       /* 
       // TODO: cursor integrate with capabilities

--- a/api/test/service/store.test.js
+++ b/api/test/service/store.test.js
@@ -245,7 +245,7 @@ test('store/list returns items previously stored by the user', async (t) => {
   links.reverse()
   let i = 0
   for (const entry of storeList.results) {
-    t.like(entry, { payloadCID: links[i].toString(), size: 5, origin: '' })
+    t.like(entry, { payloadCID: links[i].toString(), size: 5 })
     i++
   }
 })


### PR DESCRIPTION
Not includes origin property with empty string value on `store/list` per https://github.com/web3-storage/upload-api/issues/16#issuecomment-1318405985