### PR TITLE
feat: add GET / and /version handlers

### DIFF
--- a/api/functions/get.js
+++ b/api/functions/get.js
@@ -6,7 +6,7 @@ import getServiceDid from '../authority.js'
  * @param {import('aws-lambda').APIGatewayProxyEventV2} request 
  */
  export async function version (request) {
-  const { NAME: name , VERSION: version, COMMIT: commit, BRANCH: branch, STAGE: env } = process.env
+  const { NAME: name , VERSION: version, COMMIT: commit, STAGE: env } = process.env
   const serviceSigner = await getServiceDid()
   const did = serviceSigner.did()
   const repo = 'https://github.com/web3-storage/upload-api'
@@ -15,7 +15,7 @@ import getServiceDid from '../authority.js'
     headers: {
       'Content-Type': `application/json`
     },
-    body: JSON.stringify({ name, version, did, repo, commit, branch, env })
+    body: JSON.stringify({ name, version, did, repo, commit, env })
   }
 }
 
@@ -33,7 +33,7 @@ export async function home (request) {
   return {
     statusCode: 200,
     headers: {
-      'Content-Type': 'text/plain'
+      'Content-Type': 'text/plain; charset=utf-8'
     },
     body: `⁂ upload-api v${version} ${env}\n- ${repo}\n- ${did}\n`
   }

--- a/api/functions/get.js
+++ b/api/functions/get.js
@@ -15,7 +15,7 @@ import getServiceDid from '../authority.js'
     headers: {
       'Content-Type': `application/json`
     },
-    body: JSON.stringify({ name, version, did, repo, branch, commit, env })
+    body: JSON.stringify({ name, version, did, repo, commit, branch, env })
   }
 }
 

--- a/api/functions/get.js
+++ b/api/functions/get.js
@@ -26,21 +26,14 @@ import getServiceDid from '../authority.js'
  */
 export async function home (request) {
   const { VERSION: version } = process.env
+  const serviceSigner = await getServiceDid()
+  const did = serviceSigner.did()
+  const repo = 'https://github.com/web3-storage/upload-api'
   return {
     statusCode: 200,
     headers: {
       'Content-Type': 'text/plain'
     },
-    /* eslint-disable no-useless-escape */
-    body: `
-           ________                    ._.
-  __  _  __\_____  \     __ __ ______  | |
-  \ \/ \/ /  _(__  <    |  |  \\____ \ | |
-   \     /  /       \   |  |  /|  |_> > \|
-    \/\_/  /______  /   |____/ |   __/  __
-                  \/           |__|     \/
-                         upload-api v${version} 
-`
-    /* eslint-enable no-useless-escape */
+    body: `⁂ upload-api v${version}\n- ${repo}\n- ${did}\n`
   }
 }

--- a/api/functions/get.js
+++ b/api/functions/get.js
@@ -1,0 +1,46 @@
+import getServiceDid from '../authority.js'
+
+/**
+ * AWS HTTP Gateway handler for GET /version
+ *
+ * @param {import('aws-lambda').APIGatewayProxyEventV2} request 
+ */
+ export async function version (request) {
+  const { NAME: name , VERSION: version } = process.env
+  const serviceSigner = await getServiceDid()
+  const did = serviceSigner.did()
+  const repo = 'https://github.com/web3-storage/upload-api'
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': `application/json`
+    },
+    body: JSON.stringify({ name, version, did, repo })
+  }
+}
+
+/**
+ * AWS HTTP Gateway handler for GET /
+ *
+ * @param {import('aws-lambda').APIGatewayProxyEventV2} request 
+ */
+export async function home (request) {
+  const { VERSION: version } = process.env
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'text/plain'
+    },
+    /* eslint-disable no-useless-escape */
+    body: `
+           ________                    ._.
+  __  _  __\_____  \     __ __ ______  | |
+  \ \/ \/ /  _(__  <    |  |  \\____ \ | |
+   \     /  /       \   |  |  /|  |_> > \|
+    \/\_/  /______  /   |____/ |   __/  __
+                  \/           |__|     \/
+                         upload-api v${version} 
+`
+    /* eslint-enable no-useless-escape */
+  }
+}

--- a/api/functions/get.js
+++ b/api/functions/get.js
@@ -6,7 +6,7 @@ import getServiceDid from '../authority.js'
  * @param {import('aws-lambda').APIGatewayProxyEventV2} request 
  */
  export async function version (request) {
-  const { NAME: name , VERSION: version } = process.env
+  const { NAME: name , VERSION: version, COMMIT: commit, BRANCH: branch, STAGE: env } = process.env
   const serviceSigner = await getServiceDid()
   const did = serviceSigner.did()
   const repo = 'https://github.com/web3-storage/upload-api'
@@ -15,7 +15,7 @@ import getServiceDid from '../authority.js'
     headers: {
       'Content-Type': `application/json`
     },
-    body: JSON.stringify({ name, version, did, repo })
+    body: JSON.stringify({ name, version, did, repo, branch, commit, env })
   }
 }
 
@@ -25,15 +25,16 @@ import getServiceDid from '../authority.js'
  * @param {import('aws-lambda').APIGatewayProxyEventV2} request 
  */
 export async function home (request) {
-  const { VERSION: version } = process.env
+  const { VERSION: version, STAGE: stage } = process.env
   const serviceSigner = await getServiceDid()
   const did = serviceSigner.did()
   const repo = 'https://github.com/web3-storage/upload-api'
+  const env = stage === 'prod' ? '' : `(${stage})`
   return {
     statusCode: 200,
     headers: {
       'Content-Type': 'text/plain'
     },
-    body: `⁂ upload-api v${version}\n- ${repo}\n- ${did}\n`
+    body: `⁂ upload-api v${version} ${env}\n- ${repo}\n- ${did}\n`
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@w3up-api/services",
-  "version": "0.0.0",
+  "name": "@web3-storage/upload-api",
+  "version": "3.0.0",
   "type": "module",
   "scripts": {
     "test": "ava --verbose --timeout=60s **/*.test.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@serverless-stack/cli": "^1.18.0",
         "@serverless-stack/resources": "^1.18.0",
         "@tsconfig/node16": "^1.0.3",
+        "@types/git-rev-sync": "^2.0.0",
         "aws-cdk-lib": "2.50.0",
         "git-rev-sync": "^3.0.2",
         "hd-scripts": "^3.0.2",
@@ -5736,6 +5737,12 @@
         "@types/docker-modem": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/git-rev-sync": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/git-rev-sync/-/git-rev-sync-2.0.0.tgz",
+      "integrity": "sha512-qGYApbb0m8Ofy3pwYks+kYVIZQAN/cqNucJGbl5O5GpLw9JSzp74rkTWDhPv3brrJfJb5/ixtimLJpo4tfh2QA==",
+      "dev": true
     },
     "node_modules/@types/glob": {
       "version": "8.0.0",
@@ -20492,6 +20499,12 @@
         "@types/docker-modem": "*",
         "@types/node": "*"
       }
+    },
+    "@types/git-rev-sync": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/git-rev-sync/-/git-rev-sync-2.0.0.tgz",
+      "integrity": "sha512-qGYApbb0m8Ofy3pwYks+kYVIZQAN/cqNucJGbl5O5GpLw9JSzp74rkTWDhPv3brrJfJb5/ixtimLJpo4tfh2QA==",
+      "dev": true
     },
     "@types/glob": {
       "version": "8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@serverless-stack/resources": "^1.18.0",
         "@tsconfig/node16": "^1.0.3",
         "aws-cdk-lib": "2.50.0",
+        "git-rev-sync": "^3.0.2",
         "hd-scripts": "^3.0.2",
         "lint-staged": "^13.0.3",
         "typescript": "^4.9.3"
@@ -10448,6 +10449,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/git-rev-sync": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-3.0.2.tgz",
+      "integrity": "sha512-Nd5RiYpyncjLv0j6IONy0lGzAqdRXUaBctuGBbrEA2m6Bn4iDrN/9MeQTXuiquw8AEKL9D2BW0nw5m/lQvxqnQ==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "1.0.5",
+        "graceful-fs": "4.1.15",
+        "shelljs": "0.8.5"
+      }
+    },
+    "node_modules/git-rev-sync/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/git-rev-sync/node_modules/graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -11057,6 +11084,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/ip": {
@@ -13878,6 +13914,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/regexp-tree": {
       "version": "0.1.24",
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
@@ -14261,6 +14309,23 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/side-channel": {
@@ -23868,6 +23933,31 @@
         "get-intrinsic": "^1.1.1"
       }
     },
+    "git-rev-sync": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-3.0.2.tgz",
+      "integrity": "sha512-Nd5RiYpyncjLv0j6IONy0lGzAqdRXUaBctuGBbrEA2m6Bn4iDrN/9MeQTXuiquw8AEKL9D2BW0nw5m/lQvxqnQ==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "graceful-fs": "4.1.15",
+        "shelljs": "0.8.5"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "dev": true
+        }
+      }
+    },
     "glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -24300,6 +24390,12 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
     },
     "ip": {
       "version": "2.0.0",
@@ -26292,6 +26388,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regexp-tree": {
       "version": "0.1.24",
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
@@ -26563,6 +26668,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "side-channel": {
       "version": "1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,8 @@
       }
     },
     "api": {
-      "name": "@w3up-api/services",
-      "version": "0.0.0",
+      "name": "@web3-storage/upload-api",
+      "version": "3.0.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.211.0",
         "@aws-sdk/client-s3": "^3.211.0",
@@ -6201,10 +6201,6 @@
         "multiformats": "^10.0.2"
       }
     },
-    "node_modules/@w3up-api/services": {
-      "resolved": "api",
-      "link": true
-    },
     "node_modules/@web-std/blob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.4.tgz",
@@ -6304,6 +6300,10 @@
       "dependencies": {
         "@noble/hashes": "^1.0.0"
       }
+    },
+    "node_modules/@web3-storage/upload-api": {
+      "resolved": "api",
+      "link": true
     },
     "node_modules/@zxing/text-encoding": {
       "version": "0.9.0",
@@ -20770,29 +20770,6 @@
         "multiformats": "^10.0.2"
       }
     },
-    "@w3up-api/services": {
-      "version": "file:api",
-      "requires": {
-        "@aws-sdk/client-dynamodb": "^3.211.0",
-        "@aws-sdk/client-s3": "^3.211.0",
-        "@aws-sdk/util-dynamodb": "^3.211.0",
-        "@ipld/car": "^5.0.1",
-        "@ipld/dag-ucan": "^2.0.1",
-        "@types/aws-lambda": "^8.10.108",
-        "@ucanto/core": "^3.0.2",
-        "@ucanto/interface": "^3.0.1",
-        "@ucanto/principal": "^3.0.1",
-        "@ucanto/server": "^3.0.4",
-        "@ucanto/transport": "^3.0.2",
-        "@web-std/blob": "3.0.4",
-        "@web3-storage/access": "^5.0.2",
-        "@web3-storage/sigv4": "^1.0.2",
-        "ava": "^4.3.3",
-        "multiformats": "^10.0.2",
-        "nanoid": "^4.0.0",
-        "testcontainers": "^8.13.0"
-      }
-    },
     "@web-std/blob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.4.tgz",
@@ -20887,6 +20864,29 @@
       "integrity": "sha512-ZUXKK10NmuQgPkqByhb1H3OQxkIM0CIn2BMPhGQw7vQw8WIzrBkk9IJiAVfJ/UVBFrf6uzPbx2lEBLt4diCMnQ==",
       "requires": {
         "@noble/hashes": "^1.0.0"
+      }
+    },
+    "@web3-storage/upload-api": {
+      "version": "file:api",
+      "requires": {
+        "@aws-sdk/client-dynamodb": "^3.211.0",
+        "@aws-sdk/client-s3": "^3.211.0",
+        "@aws-sdk/util-dynamodb": "^3.211.0",
+        "@ipld/car": "^5.0.1",
+        "@ipld/dag-ucan": "^2.0.1",
+        "@types/aws-lambda": "^8.10.108",
+        "@ucanto/core": "^3.0.2",
+        "@ucanto/interface": "^3.0.1",
+        "@ucanto/principal": "^3.0.1",
+        "@ucanto/server": "^3.0.4",
+        "@ucanto/transport": "^3.0.2",
+        "@web-std/blob": "3.0.4",
+        "@web3-storage/access": "^5.0.2",
+        "@web3-storage/sigv4": "^1.0.2",
+        "ava": "^4.3.3",
+        "multiformats": "^10.0.2",
+        "nanoid": "^4.0.0",
+        "testcontainers": "^8.13.0"
       }
     },
     "@zxing/text-encoding": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@serverless-stack/resources": "^1.18.0",
     "@tsconfig/node16": "^1.0.3",
     "aws-cdk-lib": "2.50.0",
+    "git-rev-sync": "^3.0.2",
     "hd-scripts": "^3.0.2",
     "lint-staged": "^13.0.3",
     "typescript": "^4.9.3"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@serverless-stack/cli": "^1.18.0",
     "@serverless-stack/resources": "^1.18.0",
     "@tsconfig/node16": "^1.0.3",
+    "@types/git-rev-sync": "^2.0.0",
     "aws-cdk-lib": "2.50.0",
     "git-rev-sync": "^3.0.2",
     "hd-scripts": "^3.0.2",

--- a/stacks/api-stack.js
+++ b/stacks/api-stack.js
@@ -3,7 +3,6 @@ import {
   Bucket,
   Table
 } from '@serverless-stack/resources'
-import { App } from 'aws-cdk-lib'
 
 import { getConfig, getCustomDomain, getApiPackageJson, getGitInfo } from './config.js'
 

--- a/stacks/api-stack.js
+++ b/stacks/api-stack.js
@@ -4,7 +4,7 @@ import {
   Table
 } from '@serverless-stack/resources'
 
-import { getConfig, getCustomDomain } from './config.js'
+import { getConfig, getCustomDomain, getApiPackageJson } from './config.js'
 
 /**
  * @param {import('@serverless-stack/resources').StackContext} properties
@@ -60,6 +60,8 @@ export function ApiStack({ stack }) {
 
   const customDomain = getCustomDomain(stack.stage, process.env.HOSTED_ZONE)
 
+  const pkg = getApiPackageJson()
+
   const api = new Api(stack, 'http-gateway', {
     customDomain,
     defaults: {
@@ -68,12 +70,16 @@ export function ApiStack({ stack }) {
         environment: {
           STORE_TABLE_NAME: storeTable.tableName,
           STORE_BUCKET_NAME: storeBucket.bucketName,
-          UPLOAD_TABLE_NAME: uploadTable.tableName
+          UPLOAD_TABLE_NAME: uploadTable.tableName,
+          NAME: pkg.name,
+          VERSION: pkg.version,
         }
       }
     },
     routes: {
-      'POST /': 'functions/ucan-invocation-router.handler',
+      'POST /':        'functions/ucan-invocation-router.handler',
+       'GET /':        'functions/get.home',
+       'GET /version': 'functions/get.version'
     },
   })
 
@@ -82,3 +88,4 @@ export function ApiStack({ stack }) {
     CustomDomain:  customDomain ? `https://${customDomain.domainName}` : 'Set HOSTED_ZONE in env to deploy to a custom domain'
   })
 }
+

--- a/stacks/api-stack.js
+++ b/stacks/api-stack.js
@@ -75,7 +75,6 @@ export function ApiStack({ stack }) {
           NAME: pkg.name,
           VERSION: pkg.version,
           COMMIT: git.commmit,
-          BRANCH: git.branch,
           STAGE: stack.stage
         }
       }

--- a/stacks/api-stack.js
+++ b/stacks/api-stack.js
@@ -3,8 +3,9 @@ import {
   Bucket,
   Table
 } from '@serverless-stack/resources'
+import { App } from 'aws-cdk-lib'
 
-import { getConfig, getCustomDomain, getApiPackageJson } from './config.js'
+import { getConfig, getCustomDomain, getApiPackageJson, getGitInfo } from './config.js'
 
 /**
  * @param {import('@serverless-stack/resources').StackContext} properties
@@ -61,6 +62,7 @@ export function ApiStack({ stack }) {
   const customDomain = getCustomDomain(stack.stage, process.env.HOSTED_ZONE)
 
   const pkg = getApiPackageJson()
+  const git = getGitInfo()
 
   const api = new Api(stack, 'http-gateway', {
     customDomain,
@@ -73,6 +75,9 @@ export function ApiStack({ stack }) {
           UPLOAD_TABLE_NAME: uploadTable.tableName,
           NAME: pkg.name,
           VERSION: pkg.version,
+          COMMIT: git.commmit,
+          BRANCH: git.branch,
+          STAGE: stack.stage
         }
       }
     },

--- a/stacks/config.js
+++ b/stacks/config.js
@@ -1,6 +1,7 @@
 // TREAT THIS THE SAME AS AN ENV FILE
 // DO NOT INCLUDE SECRETS IN IT
 import { RemovalPolicy } from 'aws-cdk-lib'
+import { createRequire } from "module"
 
 const stageConfigs = {
   dev: {
@@ -66,4 +67,12 @@ export function getCustomDomain (stage, hostedZone) {
   const domainMap = { prod: hostedZone }
   const domainName = domainMap[stage] ?? `${stage}.${hostedZone}`
   return { domainName, hostedZone }
+}
+
+export function getApiPackageJson () {
+  // @ts-expect-error ts thinks this is unused becuase of the ignore
+  const require = createRequire(import.meta.url)
+  // @ts-ignore ts dont see *.json and dont like it
+  const pkg = require('../api/package.json')
+  return pkg
 }

--- a/stacks/config.js
+++ b/stacks/config.js
@@ -2,6 +2,7 @@
 // DO NOT INCLUDE SECRETS IN IT
 import { RemovalPolicy } from 'aws-cdk-lib'
 import { createRequire } from "module"
+import git from 'git-rev-sync'
 
 const stageConfigs = {
   dev: {
@@ -75,4 +76,11 @@ export function getApiPackageJson () {
   // @ts-ignore ts dont see *.json and dont like it
   const pkg = require('../../api/package.json')
   return pkg
+}
+
+export function getGitInfo () {
+  return {
+    commmit: git.long('.'),
+    branch: git.branch('.')
+  }
 }

--- a/stacks/config.js
+++ b/stacks/config.js
@@ -73,6 +73,6 @@ export function getApiPackageJson () {
   // @ts-expect-error ts thinks this is unused becuase of the ignore
   const require = createRequire(import.meta.url)
   // @ts-ignore ts dont see *.json and dont like it
-  const pkg = require('../api/package.json')
+  const pkg = require('../../api/package.json')
   return pkg
 }


### PR DESCRIPTION
Adds handlers for `GET /` and `GET /version`.

`GET /` is `text/plain` for humans

```bash
❯ curl https://pr32.up.web3.storage
⁂ upload-api v3.0.0 (pr32)
- https://github.com/web3-storage/upload-api
- did:key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z
```

`GET /version` is `application/json` for robots

```bash
❯ curl https://pr32.up.web3.storage/version -s | jq
{
  "name": "@web3-storage/upload-api",
  "version": "3.0.0",
  "did": "did:key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z",
  "repo": "https://github.com/web3-storage/upload-api",
  "commit": "0ec7b1099a99adf338f81842686cd2c88f6f449b",
  "env": "pr32"
}
```

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>