### PR TITLE
chore: restructure tests to start container per test file

### DIFF
--- a/api/tables/store.js
+++ b/api/tables/store.js
@@ -61,14 +61,14 @@ export function createStoreTable (region, tableName, options = {}) {
         proof,
         uploadedAt: new Date().toISOString(),
       }
-  
+
       const cmd = new PutItemCommand({
         TableName: tableName,
         Item: marshall(item),
       })
-  
+
       await dynamoDb.send(cmd)
-  
+
       return item
     },
     /**

--- a/api/test/helpers/context.js
+++ b/api/test/helpers/context.js
@@ -3,10 +3,7 @@ import anyTest from 'ava'
 /**
  * @typedef {object} UcantoServerContext
  * @property {string} dbEndpoint
- * @property {string} tableName
  * @property {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoClient
- * @property {string} region
- * @property {string} bucketName
  * @property {import('@aws-sdk/client-s3').S3Client} s3Client
  * @property {import('@aws-sdk/client-s3').ServiceInputTypes} s3ClientOpts
  * @property {import('@ucanto/principal/ed25519').EdSigner} serviceDid

--- a/api/test/helpers/ucanto.js
+++ b/api/test/helpers/ucanto.js
@@ -13,42 +13,41 @@ import { createAccessClient } from '../../access.js'
 
 /**
  * @typedef {object} ResourcesMetadata
- * @property {string} region
+ * @property {string} [region]
  * @property {string} tableName
  * @property {string} bucketName
  */
 
 /**
  * @param {import('@ucanto/interface').Signer} service
- * @param {import('./context.js').UcantoServerContext} ctx
- * @param {ResourcesMetadata} resourcesMetadata
+ * @param {import('./context.js').UcantoServerContext & ResourcesMetadata} ctx
  */
-export function createTestingUcantoServer(service, ctx, resourcesMetadata) {
+export function createTestingUcantoServer(service, ctx) {
+  const region = ctx.region || 'us-west-2'
  return createUcantoServer(service, {
-   storeTable: createStoreTable(resourcesMetadata.region, resourcesMetadata.tableName, {
+   storeTable: createStoreTable(region, ctx.tableName, {
      endpoint: ctx.dbEndpoint
    }),
-   uploadTable: createUploadTable(resourcesMetadata.region, resourcesMetadata.tableName, {
+   uploadTable: createUploadTable(region, ctx.tableName, {
      endpoint: ctx.dbEndpoint
    }),
-   carStoreBucket: createCarStore(resourcesMetadata.region, resourcesMetadata.bucketName, { ...ctx.s3ClientOpts }),
-   signer: createSigner(getSigningOptions(ctx, resourcesMetadata)),
+   carStoreBucket: createCarStore(region, ctx.bucketName, { ...ctx.s3ClientOpts }),
+   signer: createSigner(getSigningOptions(ctx, ctx)),
    access: createAccessClient(service, ctx.access.servicePrincipal, ctx.access.serviceURL)
  })
 }
 
 /**
  * @param {import('@ucanto/interface').Signer} service
- * @param {any} context 
- * @param {ResourcesMetadata} resourcesMetadata
+ * @param {any} context
  * @returns 
  */
-export async function getClientConnection (service, context, resourcesMetadata) {
+export async function getClientConnection (service, context) {
   return UcantoClient.connect({
     id: service,
     encoder: CAR,
     decoder: CBOR,
-    channel: await createTestingUcantoServer(service, context, resourcesMetadata),
+    channel: await createTestingUcantoServer(service, context),
   })
 }
 

--- a/api/test/helpers/ucanto.js
+++ b/api/test/helpers/ucanto.js
@@ -12,19 +12,27 @@ import { getSigningOptions } from '../utils.js'
 import { createAccessClient } from '../../access.js'
 
 /**
+ * @typedef {object} ResourcesMetadata
+ * @property {string} region
+ * @property {string} tableName
+ * @property {string} bucketName
+ */
+
+/**
  * @param {import('@ucanto/interface').Signer} service
  * @param {import('./context.js').UcantoServerContext} ctx
+ * @param {ResourcesMetadata} resourcesMetadata
  */
-export function createTestingUcantoServer(service, ctx) {
+export function createTestingUcantoServer(service, ctx, resourcesMetadata) {
  return createUcantoServer(service, {
-   storeTable: createStoreTable(ctx.region, ctx.tableName, {
+   storeTable: createStoreTable(resourcesMetadata.region, resourcesMetadata.tableName, {
      endpoint: ctx.dbEndpoint
    }),
-   uploadTable: createUploadTable(ctx.region, ctx.tableName, {
+   uploadTable: createUploadTable(resourcesMetadata.region, resourcesMetadata.tableName, {
      endpoint: ctx.dbEndpoint
    }),
-   carStoreBucket: createCarStore(ctx.region, ctx.bucketName, { ...ctx.s3ClientOpts }),
-   signer: createSigner(getSigningOptions(ctx)),
+   carStoreBucket: createCarStore(resourcesMetadata.region, resourcesMetadata.bucketName, { ...ctx.s3ClientOpts }),
+   signer: createSigner(getSigningOptions(ctx, resourcesMetadata)),
    access: createAccessClient(service, ctx.access.servicePrincipal, ctx.access.serviceURL)
  })
 }
@@ -32,14 +40,15 @@ export function createTestingUcantoServer(service, ctx) {
 /**
  * @param {import('@ucanto/interface').Signer} service
  * @param {any} context 
+ * @param {ResourcesMetadata} resourcesMetadata
  * @returns 
  */
-export async function getClientConnection (service, context) {
+export async function getClientConnection (service, context, resourcesMetadata) {
   return UcantoClient.connect({
     id: service,
     encoder: CAR,
     decoder: CBOR,
-    channel: await createTestingUcantoServer(service, context),
+    channel: await createTestingUcantoServer(service, context, resourcesMetadata),
   })
 }
 

--- a/api/test/service/store.test.js
+++ b/api/test/service/store.test.js
@@ -1,4 +1,5 @@
 import { testStore as test } from '../helpers/context.js'
+import { customAlphabet } from 'nanoid'
 import { CreateTableCommand, GetItemCommand } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { PutObjectCommand } from '@aws-sdk/client-s3'
@@ -15,21 +16,28 @@ import { createS3, createBucket, createDynamodDb, createAccessServer } from '../
  * @typedef {import('../../service/types').ListResponse<StoreListResult>} ListResponse
  */
 
-test.beforeEach(async t => {
-  const region = 'us-west-2'
-  const tableName = 'store'
+const REGION = 'us-west-2'
 
+test.before(async t => {
   // Dynamo DB
   const {
     client: dynamo,
     endpoint: dbEndpoint
-  } = await createDynamodDb({ port: 8000, region })
-  await createDynamoStoreTable(dynamo)
+  } = await createDynamodDb({ port: 8000, region: REGION })
 
-  // Bucket
-  const { client: s3Client, clientOpts: s3ClientOpts } = await createS3({ port: 9000, region })
-  const bucketName = await createBucket(s3Client)
+  t.context.dbEndpoint = dbEndpoint
+  t.context.dynamoClient = dynamo
 
+  // S3
+  const { client: s3Client, clientOpts: s3ClientOpts } = await createS3({ port: 9000, region: REGION })
+
+  t.context.dbEndpoint = dbEndpoint
+  t.context.dynamoClient = dynamo
+  t.context.s3Client = s3Client
+  t.context.s3ClientOpts = s3ClientOpts
+})
+
+test.beforeEach(async t => {
   // Access
   const access = await createAccessServer()
   // return a mock info by default
@@ -46,13 +54,6 @@ test.beforeEach(async t => {
     }
   })
 
-  t.context.dbEndpoint = dbEndpoint
-  t.context.dynamoClient = dynamo
-  t.context.tableName = tableName
-  t.context.region = region
-  t.context.bucketName = bucketName
-  t.context.s3Client = s3Client
-  t.context.s3ClientOpts = s3ClientOpts
   t.context.access = access
   t.context.accessServiceDID = access.servicePrincipal.did()
   t.context.accessServiceURL = access.serviceURL.toString()
@@ -63,10 +64,16 @@ test.afterEach(async t => {
 })
 
 test('store/add returns signed url for uploading', async (t) => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3Client)
+
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context)
+  const connection = await getClientConnection(uploadService, t.context, {
+    region: REGION,
+    tableName,
+    bucketName
+  })
 
   const data = new Uint8Array([11, 22, 34, 44, 55])
   const link = await CAR.codec.link(data)
@@ -90,7 +97,7 @@ test('store/add returns signed url for uploading', async (t) => {
   t.is(storeAdd.url && new URL(storeAdd.url).pathname, `/${link}/${link}.car`)
   t.is(storeAdd.headers && storeAdd.headers['x-amz-checksum-sha256'], base64pad.baseEncode(link.multihash.digest))
 
-  const item = await getItemFromStoreTable(t.context.dynamoClient, spaceDid, link)
+  const item = await getItemFromStoreTable(t.context.dynamoClient, tableName, spaceDid, link)
   t.truthy(item)
   t.is(typeof item?.uploadedAt, 'string')
   t.is(typeof item?.proof, 'string')
@@ -102,10 +109,16 @@ test('store/add returns signed url for uploading', async (t) => {
 })
 
 test('store/add returns done if already uploaded', async (t) => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3Client)
+
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context)
+  const connection = await getClientConnection(uploadService, t.context, {
+    region: REGION,
+    tableName,
+    bucketName
+  })
 
   const data = new Uint8Array([11, 22, 34, 44, 55])
   const link = await CAR.codec.link(data)
@@ -113,7 +126,7 @@ test('store/add returns done if already uploaded', async (t) => {
   // simulate an already stored CAR
   await t.context.s3Client.send(
     new PutObjectCommand({
-      Bucket: t.context.bucketName,
+      Bucket: bucketName,
       Key: `${link}/${link}.car`,
       Body: data,
     })
@@ -137,7 +150,7 @@ test('store/add returns done if already uploaded', async (t) => {
   t.falsy(storeAdd.url)
 
   // Even if done (CAR already exists in bucket), mapped to user if non existing
-  const item = await getItemFromStoreTable(t.context.dynamoClient, spaceDid, link)
+  const item = await getItemFromStoreTable(t.context.dynamoClient, tableName, spaceDid, link)
   t.is(typeof item?.uploadedAt, 'string')
   t.is(typeof item?.proof, 'string')
   t.is(typeof item?.uploaderDID, 'string')
@@ -147,10 +160,16 @@ test('store/add returns done if already uploaded', async (t) => {
 })
 
 test('store/add allowed if invocation passes access verification', async (t) => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3Client)
+
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context)
+  const connection = await getClientConnection(uploadService, t.context, {
+    region: REGION,
+    tableName,
+    bucketName
+  })
 
   const data = new Uint8Array([11, 22, 34, 44, 55])
   const link = await CAR.codec.link(data)
@@ -180,6 +199,8 @@ test('store/add allowed if invocation passes access verification', async (t) => 
 })
 
 test('store/add disallowed if invocation fails access verification', async (t) => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3Client)
+
   t.context.access.setServiceImpl({
     account: { info: () => { return new Server.Failure('not found') } }
   })
@@ -187,7 +208,11 @@ test('store/add disallowed if invocation fails access verification', async (t) =
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context)
+  const connection = await getClientConnection(uploadService, t.context, {
+    region: REGION,
+    tableName,
+    bucketName
+  })
 
   const data = new Uint8Array([11, 22, 34, 44, 55])
   const link = await CAR.codec.link(data)
@@ -209,10 +234,16 @@ test('store/add disallowed if invocation fails access verification', async (t) =
 })
 
 test('store/remove does not fail for non existent link', async (t) => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3Client)
+
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context)
+  const connection = await getClientConnection(uploadService, t.context, {
+    region: REGION,
+    tableName,
+    bucketName
+  })
 
   const data = new Uint8Array([11, 22, 34, 44, 55])
   const link = await CAR.codec.link(data)
@@ -241,16 +272,22 @@ test('store/remove does not fail for non existent link', async (t) => {
 })
 
 test('store/remove removes car bound to issuer from store table', async (t) => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3Client)
+
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context)
+  const connection = await getClientConnection(uploadService, t.context, {
+    region: REGION,
+    tableName,
+    bucketName
+  })
 
   const data = new Uint8Array([11, 22, 34, 44, 55])
   const link = await CAR.codec.link(data)
 
   // Validate Store Table content does not exist before add
-  const dynamoItemBeforeAdd = await getItemFromStoreTable(t.context.dynamoClient, spaceDid, link)
+  const dynamoItemBeforeAdd = await getItemFromStoreTable(t.context.dynamoClient, tableName, spaceDid, link)
   t.falsy(dynamoItemBeforeAdd)
 
   const storeAdd = await StoreCapabilities.add.invoke({
@@ -268,7 +305,7 @@ test('store/remove removes car bound to issuer from store table', async (t) => {
   t.is(storeAdd.status, 'upload')
 
   // Validate Store Table content exists after add
-  const dynamoItemAfterAdd = await getItemFromStoreTable(t.context.dynamoClient, spaceDid, link)
+  const dynamoItemAfterAdd = await getItemFromStoreTable(t.context.dynamoClient, tableName, spaceDid, link)
   t.truthy(dynamoItemAfterAdd)
 
   const storeRemove = await StoreCapabilities.remove.invoke({
@@ -282,15 +319,21 @@ test('store/remove removes car bound to issuer from store table', async (t) => {
   t.falsy(storeRemove)
 
   // Validate Store Table content does not exist after remove
-  const dynamoItemAfterRemove = await getItemFromStoreTable(t.context.dynamoClient, spaceDid, link)
+  const dynamoItemAfterRemove = await getItemFromStoreTable(t.context.dynamoClient, tableName, spaceDid, link)
   t.falsy(dynamoItemAfterRemove)
 })
 
 test('store/list does not fail for empty list', async (t) => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3Client)
+
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context)
+  const connection = await getClientConnection(uploadService, t.context, {
+    region: REGION,
+    tableName,
+    bucketName
+  })
   
   const storeList = await StoreCapabilities.list.invoke({
     issuer: alice,
@@ -304,10 +347,16 @@ test('store/list does not fail for empty list', async (t) => {
 })
 
 test('store/list returns items previously stored by the user', async (t) => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3Client)
+
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context)
+  const connection = await getClientConnection(uploadService, t.context, {
+    region: REGION,
+    tableName,
+    bucketName
+  })
 
   const data = [ new Uint8Array([11, 22, 34, 44, 55]), new Uint8Array([22, 34, 44, 55, 66]) ]
   const links = []
@@ -351,10 +400,16 @@ test('store/list returns items previously stored by the user', async (t) => {
 })
 
 test('store/list can be paginated with custom size', async (t) => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3Client)
+
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context)
+  const connection = await getClientConnection(uploadService, t.context, {
+    region: REGION,
+    tableName,
+    bucketName
+  })
 
   const data = [ new Uint8Array([11, 22, 34, 44, 55]), new Uint8Array([22, 34, 44, 55, 66]) ]
   const links = []
@@ -415,12 +470,31 @@ test('store/list can be paginated with custom size', async (t) => {
 })
 
 /**
+ * @param {import("@aws-sdk/client-dynamodb").DynamoDBClient} dynamoClient
+ * @param {import("@aws-sdk/client-s3").S3Client} s3Client
+ */
+async function prepareResources (dynamoClient, s3Client) {
+  const [ tableName, bucketName ] = await Promise.all([
+    createDynamoStoreTable(dynamoClient),
+    createBucket(s3Client)
+  ])
+
+  return {
+    tableName,
+    bucketName
+  }
+}
+
+/**
  * @param {import("@aws-sdk/client-dynamodb").DynamoDBClient} dynamo
  */
 async function createDynamoStoreTable(dynamo) {
+  const id = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10)
+  const tableName = id()
+
   // TODO: see in pickup Document DB wrapper
   await dynamo.send(new CreateTableCommand({
-    TableName: 'store',
+    TableName: tableName,
     AttributeDefinitions: [
       { AttributeName: 'uploaderDID', AttributeType: 'S' },
       { AttributeName: 'payloadCID', AttributeType: 'S' }
@@ -434,16 +508,19 @@ async function createDynamoStoreTable(dynamo) {
       WriteCapacityUnits: 1
     }
   }))
+
+  return tableName
 }
 
 /**
  * @param {import("@aws-sdk/client-dynamodb").DynamoDBClient} dynamo
+ * @param {string} tableName
  * @param {`did:key:${string}`} spaceDid
  * @param {import('@ucanto/interface').Link<unknown, number, number, 0 | 1>} link
  */
-async function getItemFromStoreTable(dynamo, spaceDid, link) {
+async function getItemFromStoreTable(dynamo, tableName, spaceDid, link) {
   const params = {
-    TableName: 'store',
+    TableName: tableName,
     Key: marshall({
       uploaderDID: spaceDid,
       payloadCID: link.toString(),

--- a/api/test/service/store.test.js
+++ b/api/test/service/store.test.js
@@ -16,20 +16,18 @@ import { createS3, createBucket, createDynamodDb, createAccessServer } from '../
  * @typedef {import('../../service/types').ListResponse<StoreListResult>} ListResponse
  */
 
-const REGION = 'us-west-2'
-
 test.before(async t => {
   // Dynamo DB
   const {
     client: dynamo,
     endpoint: dbEndpoint
-  } = await createDynamodDb({ port: 8000, region: REGION })
+  } = await createDynamodDb({ port: 8000 })
 
   t.context.dbEndpoint = dbEndpoint
   t.context.dynamoClient = dynamo
 
   // S3
-  const { client: s3Client, clientOpts: s3ClientOpts } = await createS3({ port: 9000, region: REGION })
+  const { client: s3Client, clientOpts: s3ClientOpts } = await createS3({ port: 9000 })
 
   t.context.dbEndpoint = dbEndpoint
   t.context.dynamoClient = dynamo
@@ -69,8 +67,8 @@ test('store/add returns signed url for uploading', async (t) => {
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -114,8 +112,8 @@ test('store/add returns done if already uploaded', async (t) => {
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -165,8 +163,8 @@ test('store/add allowed if invocation passes access verification', async (t) => 
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -208,8 +206,8 @@ test('store/add disallowed if invocation fails access verification', async (t) =
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -239,8 +237,8 @@ test('store/remove does not fail for non existent link', async (t) => {
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -277,8 +275,8 @@ test('store/remove removes car bound to issuer from store table', async (t) => {
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -329,8 +327,8 @@ test('store/list does not fail for empty list', async (t) => {
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -352,8 +350,8 @@ test('store/list returns items previously stored by the user', async (t) => {
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -405,8 +403,8 @@ test('store/list can be paginated with custom size', async (t) => {
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })

--- a/api/test/service/upload.test.js
+++ b/api/test/service/upload.test.js
@@ -16,20 +16,19 @@ import { getClientConnection, createSpace } from '../helpers/ucanto.js'
  * @typedef {import('../../service/types').UploadItemOutput} UploadItemOutput
  * @typedef {import('../../service/types').ListResponse<UploadItemOutput>} ListResponse
  */
- const REGION = 'us-west-2'
 
  test.before(async t => {
   // Dynamo DB
   const {
     client: dynamo,
     endpoint: dbEndpoint
-  } = await createDynamodDb({ port: 8000, region: REGION })
+  } = await createDynamodDb({ port: 8000 })
 
   t.context.dbEndpoint = dbEndpoint
   t.context.dynamoClient = dynamo
 
   // S3
-  const { client: s3Client, clientOpts: s3ClientOpts } = await createS3({ port: 9000, region: REGION })
+  const { client: s3Client, clientOpts: s3ClientOpts } = await createS3({ port: 9000 })
 
   t.context.dbEndpoint = dbEndpoint
   t.context.dynamoClient = dynamo
@@ -69,8 +68,8 @@ test('upload/add inserts into DB mapping between data CID and car CIDs', async (
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -123,8 +122,8 @@ test('upload/add does not fail with no shards provided', async (t) => {
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -159,8 +158,8 @@ test('upload/remove does not fail for non existent upload', async (t) => {
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -189,8 +188,8 @@ test('upload/remove removes all entries with data CID linked to space', async (t
   const alice = await Signer.generate()
   const { proof: proofSpaceA, spaceDid: spaceDidA } = await createSpace(alice)
   const { proof: proofSpaceB, spaceDid: spaceDidB } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -265,8 +264,8 @@ test('upload/remove removes all entries when larger than batch limit', async (t)
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -316,8 +315,8 @@ test('store/list does not fail for empty list', async (t) => {
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -339,8 +338,8 @@ test('store/list returns entries previously uploaded by the user', async (t) => 
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })
@@ -386,8 +385,8 @@ test('upload/list can be paginated with custom size', async (t) => {
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { proof, spaceDid } = await createSpace(alice)
-  const connection = await getClientConnection(uploadService, t.context, {
-    region: REGION,
+  const connection = await getClientConnection(uploadService, {
+    ...t.context,
     tableName,
     bucketName
   })

--- a/api/test/utils.js
+++ b/api/test/utils.js
@@ -85,15 +85,16 @@ export async function createBucket(s3) {
 }
 
 /**
- * @param {any} ctx 
+ * @param {any} ctx
+ * @param {import('./helpers/ucanto').ResourcesMetadata} resourcesMetadata
  */
-export function getSigningOptions(ctx) {
+export function getSigningOptions(ctx, resourcesMetadata) {
   return {
-    region: ctx.region,
+    region: resourcesMetadata.region,
     secretAccessKey: ctx.secretAccessKey,
     accessKeyId: ctx.accessKeyId,
     sessionToken: ctx.sessionToken,
-    bucket: ctx.bucketName,
+    bucket: resourcesMetadata.bucketName,
   }
 }
 

--- a/api/test/utils.js
+++ b/api/test/utils.js
@@ -90,7 +90,7 @@ export async function createBucket(s3) {
  */
 export function getSigningOptions(ctx, resourcesMetadata) {
   return {
-    region: resourcesMetadata.region,
+    region: resourcesMetadata.region || 'us-west-2',
     secretAccessKey: ctx.secretAccessKey,
     accessKeyId: ctx.accessKeyId,
     sessionToken: ctx.sessionToken,


### PR DESCRIPTION
Restructure tests to start containers (DynamoDB + S3) per test file.

As discussed with @olizilla , each test creates its internal resources (tableName, bucketName) while keeping using same Docker containers:
- a simple `prepareResources` function is used to create the test specific resources
  - could be done in `beforeEach`, but this might create issues running tests in parallel as same references would be used to track tableName, bucketName
- names of the resources are propagated to `ucantoServer` creation to be used within the code (previously, they were in general context)
- creating access mock server in `beforeEach` still. Main reason is tests keeping track of counting calls which would be problematic. Given it does not spin any container keeping for now