### PR TITLE
feat: write mapping to dudewhere on upload add

### DIFF
--- a/api/buckets/data-cid-to-car-cid-store.js
+++ b/api/buckets/data-cid-to-car-cid-store.js
@@ -1,0 +1,34 @@
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
+
+/**
+ * Abstraction layer with Factory to perform operations on bucket storing
+ * data CID to car CID mapping. A Bucket DB informally known as DUDEWHERE.
+ *
+ * @param {string} region
+ * @param {string} bucketName
+ * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
+ * @returns {import('../service/types').DataCidCarCidMapBucket}
+ */
+export function createDataCidToCarCidStore (region, bucketName, options = {}) {
+  const s3client = new S3Client({
+    region,
+    ...options
+  })
+
+  return {
+    /**
+     * Put dataCID -> carCID mapping into the bucket
+     *
+     * @param {string} dataCid
+     * @param {string} carCid
+     */
+    put: async (dataCid, carCid) => {
+      const putCmd = new PutObjectCommand({
+        Bucket: bucketName,
+        Key: `${dataCid}/${carCid}`,
+        ContentLength: 0,
+      })
+      await s3client.send(putCmd)
+    }
+  }
+}

--- a/api/buckets/dudewhere-store.js
+++ b/api/buckets/dudewhere-store.js
@@ -7,9 +7,9 @@ import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
  * @param {string} region
  * @param {string} bucketName
  * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
- * @returns {import('../service/types').DataCidCarCidMapBucket}
+ * @returns {import('../service/types').DudewhereBucket}
  */
-export function createDataCidToCarCidStore (region, bucketName, options = {}) {
+export function createDudewhereStore (region, bucketName, options = {}) {
   const s3client = new S3Client({
     region,
     ...options

--- a/api/functions/ucan-invocation-router.js
+++ b/api/functions/ucan-invocation-router.js
@@ -2,7 +2,7 @@ import { DID } from '@ucanto/core'
 import { createAccessClient } from '../access.js'
 import { createSigner } from '../signer.js'
 import { createCarStore } from '../buckets/car-store.js'
-import { createDataCidToCarCidStore } from '../buckets/data-cid-to-car-cid-store.js'
+import { createDudewhereStore } from '../buckets/dudewhere-store.js'
 import { createStoreTable } from '../tables/store.js'
 import { createUploadTable } from '../tables/upload.js'
 import { getServiceSigner } from '../config.js'
@@ -13,13 +13,12 @@ const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || ''
 const AWS_SESSION_TOKEN = process.env.AWS_SESSION_TOKEN || ''
 const AWS_REGION = process.env.AWS_REGION || 'us-west-2'
 
-
-// TODO: Should use secrets for this or inject here?
+// Specified in SST environment
 const REPLICATOR_ACCESS_KEY_ID = process.env.REPLICATOR_ACCESS_KEY_ID || ''
 const REPLICATOR_SECRET_ACCESS_KEY = process.env.REPLICATOR_SECRET_ACCESS_KEY || ''
 const REPLICATOR_REGION = process.env.REPLICATOR_REGION || 'global'
-const REPLICATOR_DUDE_WHERE_BUCKET_NAME =
-  process.env.REPLICATOR_DUDE_WHERE_BUCKET_NAME || ''
+const REPLICATOR_DUDEWHERE_BUCKET_NAME =
+  process.env.REPLICATOR_DUDEWHERE_BUCKET_NAME || ''
 const REPLICATOR_ENDPOINT = process.env.REPLICATOR_ENDPOINT || ``
 
 /**
@@ -53,9 +52,9 @@ async function ucanInvocationRouter (request) {
       endpoint: dbEndpoint
     }),
     carStoreBucket: createCarStore(AWS_REGION, storeBucketName),
-    dataCidCarCidMapBucket: createDataCidToCarCidStore(
+    dudewhereBucket: createDudewhereStore(
       REPLICATOR_REGION,
-      REPLICATOR_DUDE_WHERE_BUCKET_NAME,
+      REPLICATOR_DUDEWHERE_BUCKET_NAME,
       {
         endpoint: REPLICATOR_ENDPOINT,
         credentials: {

--- a/api/functions/ucan-invocation-router.js
+++ b/api/functions/ucan-invocation-router.js
@@ -14,7 +14,7 @@ const AWS_SESSION_TOKEN = process.env.AWS_SESSION_TOKEN || ''
 const AWS_REGION = process.env.AWS_REGION || 'us-west-2'
 
 
-// TODO: Should we use secrets for this or inject here?
+// TODO: Should use secrets for this or inject here?
 const REPLICATOR_ACCESS_KEY_ID = process.env.REPLICATOR_ACCESS_KEY_ID || ''
 const REPLICATOR_SECRET_ACCESS_KEY = process.env.REPLICATOR_SECRET_ACCESS_KEY || ''
 const REPLICATOR_REGION = process.env.REPLICATOR_REGION || 'global'

--- a/api/functions/ucan-invocation-router.js
+++ b/api/functions/ucan-invocation-router.js
@@ -2,6 +2,7 @@ import { DID } from '@ucanto/core'
 import { createAccessClient } from '../access.js'
 import { createSigner } from '../signer.js'
 import { createCarStore } from '../buckets/car-store.js'
+import { createDataCidToCarCidStore } from '../buckets/data-cid-to-car-cid-store.js'
 import { createStoreTable } from '../tables/store.js'
 import { createUploadTable } from '../tables/upload.js'
 import { getServiceSigner } from '../config.js'
@@ -11,6 +12,15 @@ const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || ''
 const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || ''
 const AWS_SESSION_TOKEN = process.env.AWS_SESSION_TOKEN || ''
 const AWS_REGION = process.env.AWS_REGION || 'us-west-2'
+
+
+// TODO: Should we use secrets for this or inject here?
+const REPLICATOR_ACCESS_KEY_ID = process.env.REPLICATOR_ACCESS_KEY_ID || ''
+const REPLICATOR_SECRET_ACCESS_KEY = process.env.REPLICATOR_SECRET_ACCESS_KEY || ''
+const REPLICATOR_REGION = process.env.REPLICATOR_REGION || 'global'
+const REPLICATOR_DUDE_WHERE_BUCKET_NAME =
+  process.env.REPLICATOR_DUDE_WHERE_BUCKET_NAME || ''
+const REPLICATOR_ENDPOINT = process.env.REPLICATOR_ENDPOINT || ``
 
 /**
  * AWS HTTP Gateway handler for POST / with ucan invocation router.
@@ -43,6 +53,17 @@ async function ucanInvocationRouter (request) {
       endpoint: dbEndpoint
     }),
     carStoreBucket: createCarStore(AWS_REGION, storeBucketName),
+    dataCidCarCidMapBucket: createDataCidToCarCidStore(
+      REPLICATOR_REGION,
+      REPLICATOR_DUDE_WHERE_BUCKET_NAME,
+      {
+        endpoint: REPLICATOR_ENDPOINT,
+        credentials: {
+          accessKeyId: REPLICATOR_ACCESS_KEY_ID,
+          secretAccessKey: REPLICATOR_SECRET_ACCESS_KEY,
+        },
+      }
+    ),
     uploadTable: createUploadTable(AWS_REGION, uploadTableName, {
       endpoint: dbEndpoint
     }),

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,8 @@
     "@web-std/fetch": "^4.1.0",
     "@web3-storage/access": "^6.0.1",
     "@web3-storage/sigv4": "^1.0.2",
-    "multiformats": "^10.0.2"
+    "multiformats": "^10.0.2",
+    "p-retry": "^5.1.2"
   },
   "devDependencies": {
     "@ipld/car": "^5.0.1",

--- a/api/service/types.ts
+++ b/api/service/types.ts
@@ -41,7 +41,7 @@ export interface StoreServiceContext {
 
 export interface UploadServiceContext {
   uploadTable: UploadTable,
-  dataCidCarCidMapBucket: DataCidCarCidMapBucket
+  dudewhereBucket: DudewhereBucket
 }
 
 export interface UcantoServerContext extends StoreServiceContext, UploadServiceContext {}
@@ -50,7 +50,7 @@ export interface CarStoreBucket {
   has: (key: string) => Promise<boolean>
 }
 
-export interface DataCidCarCidMapBucket {
+export interface DudewhereBucket {
   put: (dataCid: string, carCid: string) => Promise<void>
 }
 

--- a/api/service/types.ts
+++ b/api/service/types.ts
@@ -39,14 +39,19 @@ export interface StoreServiceContext {
   access: AccessClient
 }
 
-export interface UcantoServerContext extends StoreServiceContext, UploadServiceContext {}
-
 export interface UploadServiceContext {
-  uploadTable: UploadTable
+  uploadTable: UploadTable,
+  dataCidCarCidMapBucket: DataCidCarCidMapBucket
 }
+
+export interface UcantoServerContext extends StoreServiceContext, UploadServiceContext {}
 
 export interface CarStoreBucket {
   has: (key: string) => Promise<boolean>
+}
+
+export interface DataCidCarCidMapBucket {
+  put: (dataCid: string, carCid: string) => Promise<void>
 }
 
 export interface StoreTable {

--- a/api/service/upload/add.js
+++ b/api/service/upload/add.js
@@ -33,7 +33,7 @@ export function uploadAddProvider(context) {
           invocation: invocation.cid
         }),
         writeDataCidToCarCidsMapping(
-          context.dataCidCarCidMapBucket,
+          context.dudewhereBucket,
           root,
           shards
         )
@@ -44,15 +44,16 @@ export function uploadAddProvider(context) {
 }
 
 
- /**
+/**
  * Writes to a "bucket DB" the mapping from a data CID to the car CIDs it is composed of.
  * Retries up to 3 times, in case of failures.
- * @param {import('../types').DataCidCarCidMapBucket} dataCidCarCidMapStore
+ *
+ * @param {import("../types").DudewhereBucket} dudewhereStore
  * @param {Server.API.Link<unknown, number, number, 0 | 1>} root
  * @param {Server.API.Link<unknown, 514, number, 1>[] | undefined} shards
  */
  async function writeDataCidToCarCidsMapping(
-  dataCidCarCidMapStore,
+  dudewhereStore,
   root,
   shards
 ) {
@@ -61,7 +62,7 @@ export function uploadAddProvider(context) {
 
   return Promise.all(carCids.map(async (/** @type {string} */ carCid) => {
     await pRetry(
-      () => dataCidCarCidMapStore.put(dataCid, carCid),
+      () => dudewhereStore.put(dataCid, carCid),
       { retries: 3 }
     )
   }))

--- a/api/service/upload/add.js
+++ b/api/service/upload/add.js
@@ -1,3 +1,4 @@
+import pRetry from 'p-retry'
 import * as Server from '@ucanto/server'
 import * as Upload from '@web3-storage/access/capabilities/upload'
 
@@ -22,14 +23,46 @@ export function uploadAddProvider(context) {
       // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
       const space = Server.DID.parse(capability.with).did()
 
-      const res = await context.uploadTable.insert({
-        space,
-        root,
-        shards,
-        issuer: invocation.issuer.did(),
-        invocation: invocation.cid
-      })
+      const [res] = await Promise.all([
+        // Store in Database
+        context.uploadTable.insert({
+          space,
+          root,
+          shards,
+          issuer: invocation.issuer.did(),
+          invocation: invocation.cid
+        }),
+        writeDataCidToCarCidsMapping(
+          context.dataCidCarCidMapBucket,
+          root,
+          shards
+        )
+      ])
 
       return res
   })
+}
+
+
+ /**
+ * Writes to a "bucket DB" the mapping from a data CID to the car CIDs it is composed of.
+ * Retries up to 3 times, in case of failures.
+ * @param {import('../types').DataCidCarCidMapBucket} dataCidCarCidMapStore
+ * @param {Server.API.Link<unknown, number, number, 0 | 1>} root
+ * @param {Server.API.Link<unknown, 514, number, 1>[] | undefined} shards
+ */
+ async function writeDataCidToCarCidsMapping(
+  dataCidCarCidMapStore,
+  root,
+  shards
+) {
+  const dataCid = root.toString()
+  const carCids = shards?.map((/** @type {{ toString: () => any; }} */ s) => s.toString()) || []
+
+  return Promise.all(carCids.map(async (/** @type {string} */ carCid) => {
+    await pRetry(
+      () => dataCidCarCidMapStore.put(dataCid, carCid),
+      { retries: 3 }
+    )
+  }))
 }

--- a/api/test/helpers/ucanto.js
+++ b/api/test/helpers/ucanto.js
@@ -4,6 +4,7 @@ import * as Signer from '@ucanto/principal/ed25519'
 
 import { createUcantoServer } from '../../service/index.js'
 import { createCarStore } from '../../buckets/car-store.js'
+import { createDataCidToCarCidStore } from '../../buckets/data-cid-to-car-cid-store.js'
 import { createStoreTable } from '../../tables/store.js'
 import { createUploadTable } from '../../tables/upload.js'
 import { createSigner } from '../../signer.js'
@@ -31,6 +32,7 @@ export function createTestingUcantoServer(service, ctx) {
      endpoint: ctx.dbEndpoint
    }),
    carStoreBucket: createCarStore(region, ctx.bucketName, { ...ctx.s3ClientOpts }),
+   dataCidCarCidMapBucket: createDataCidToCarCidStore(region, ctx.bucketName, { ...ctx.s3ClientOpts }),
    signer: createSigner(getSigningOptions(ctx)),
    access: createAccessClient(service, ctx.access.servicePrincipal, ctx.access.serviceURL)
  })

--- a/api/test/helpers/ucanto.js
+++ b/api/test/helpers/ucanto.js
@@ -4,7 +4,7 @@ import * as Signer from '@ucanto/principal/ed25519'
 
 import { createUcantoServer } from '../../service/index.js'
 import { createCarStore } from '../../buckets/car-store.js'
-import { createDataCidToCarCidStore } from '../../buckets/data-cid-to-car-cid-store.js'
+import { createDudewhereStore } from '../../buckets/dudewhere-store.js'
 import { createStoreTable } from '../../tables/store.js'
 import { createUploadTable } from '../../tables/upload.js'
 import { createSigner } from '../../signer.js'
@@ -32,7 +32,7 @@ export function createTestingUcantoServer(service, ctx) {
      endpoint: ctx.dbEndpoint
    }),
    carStoreBucket: createCarStore(region, ctx.bucketName, { ...ctx.s3ClientOpts }),
-   dataCidCarCidMapBucket: createDataCidToCarCidStore(region, ctx.bucketName, { ...ctx.s3ClientOpts }),
+   dudewhereBucket: createDudewhereStore(region, ctx.bucketName, { ...ctx.s3ClientOpts }),
    signer: createSigner(getSigningOptions(ctx)),
    access: createAccessClient(service, ctx.access.servicePrincipal, ctx.access.serviceURL)
  })

--- a/api/test/service/upload.test.js
+++ b/api/test/service/upload.test.js
@@ -1,6 +1,7 @@
 import { testStore as test } from '../helpers/context.js'
 import { customAlphabet } from 'nanoid'
 import { CreateTableCommand, QueryCommand } from '@aws-sdk/client-dynamodb'
+import { ListObjectsV2Command } from '@aws-sdk/client-s3'
 import { unmarshall } from '@aws-sdk/util-dynamodb'
 import * as Signer from '@ucanto/principal/ed25519'
 import * as UploadCapabilities from '@web3-storage/access/capabilities/upload'
@@ -113,6 +114,12 @@ test('upload/add inserts into DB mapping between data CID and car CIDs', async (
     t.is(shardResult?.root, root.toString())
     t.truthy(shardResult?.insertedAt)
   }
+
+  // Validate data CID -> car CID mapping
+  const bucketItems = await getMappingItemsForUpload(t.context.s3Client, bucketName, root.toString())
+  for (const shard of shards) {
+    t.truthy(bucketItems?.includes(`${root.toString()}/${shard.toString()}`))
+  }
 })
 
 // TODO: this is current behavior with optional nb.
@@ -151,6 +158,10 @@ test('upload/add does not fail with no shards provided', async (t) => {
   // Validate DB
   const dbItems = await getUploadsForSpace(t.context.dynamoClient, tableName, spaceDid)
   t.is(dbItems.length, 0)
+
+  // Validate data CID -> car CID mapping
+  const bucketItems = await getMappingItemsForUpload(t.context.s3Client, bucketName, root.toString())
+  t.is(bucketItems.length, 0)
 })
 
 test('upload/remove does not fail for non existent upload', async (t) => {
@@ -536,3 +547,17 @@ async function prepareResources (dynamoClient, s3Client) {
   return response.Items?.map(i => unmarshall(i)) || []
 }
 
+/**
+ * @param {import("@aws-sdk/client-s3").S3Client} s3Client
+ * @param {string} bucketName
+ * @param {string} dataCid
+ */
+async function getMappingItemsForUpload (s3Client, bucketName, dataCid) {
+  const listCmd = new ListObjectsV2Command({
+    Bucket: bucketName,
+    Prefix: dataCid
+  })
+  const mappingItems = await s3Client.send(listCmd)
+
+  return mappingItems.Contents?.map(i => i.Key) || []
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,8 @@
         "@web-std/fetch": "^4.1.0",
         "@web3-storage/access": "^6.0.1",
         "@web3-storage/sigv4": "^1.0.2",
-        "multiformats": "^10.0.2"
+        "multiformats": "^10.0.2",
+        "p-retry": "^5.1.2"
       },
       "devDependencies": {
         "@ipld/car": "^5.0.1",
@@ -6662,7 +6663,8 @@
     "node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
-      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "dev": true
     },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.36.1",
@@ -7042,14 +7044,14 @@
       }
     },
     "node_modules/@serverless-stack/cli": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/cli/-/cli-1.18.3.tgz",
-      "integrity": "sha512-/FmccyyUFgvmv7VKeY7hZW97KjH2MK2S6ElxRZjhotmONO6YC7SlyZsv4eBS6Ge91Xsak5BICV7niyjKcvbebg==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/cli/-/cli-1.18.4.tgz",
+      "integrity": "sha512-eEG3brlbF/ptIo/s69Hcrn185CVkLWHpmtOmere7+lMPkmy1vxNhWIUuic+LNG0yweK+sg4uMVipREyvwblNDQ==",
       "dev": true,
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2-alpha": "2.50.0-alpha.0",
-        "@serverless-stack/core": "1.18.3",
-        "@serverless-stack/resources": "1.18.3",
+        "@serverless-stack/core": "1.18.4",
+        "@serverless-stack/resources": "1.18.4",
         "aws-cdk": "2.50.0",
         "aws-cdk-lib": "2.50.0",
         "aws-sdk": "^2.1110.0",
@@ -7072,9 +7074,9 @@
       }
     },
     "node_modules/@serverless-stack/core": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/core/-/core-1.18.3.tgz",
-      "integrity": "sha512-oQTTgh2iajNNX9riZ340jOF/rWRQgSDLAr0WfuySysC9VmvLMtPwHVcWuSDvmb0pG/fkrpMErNRFtE3IvSQ/hA==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/core/-/core-1.18.4.tgz",
+      "integrity": "sha512-j6eoGoZbADbLsc95ZJZQ3nWkXqdlfayx1xEWE0UpFjxthKUi8qZUONd7NOEyTHiR0yYV1NrANcWur2alvn+vlA==",
       "dev": true,
       "dependencies": {
         "@serverless-stack/aws-lambda-ric": "^2.0.13",
@@ -7119,9 +7121,9 @@
       }
     },
     "node_modules/@serverless-stack/node": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/node/-/node-1.18.3.tgz",
-      "integrity": "sha512-bF06TCWoPikgFCgPWswzd6F8OliCsuN/62LmsSKnTIAP9aczPhL/g59hD2XLR/jtOQ6AlWyjYCplhlETdWBSQA==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/node/-/node-1.18.4.tgz",
+      "integrity": "sha512-j2/Iolg9HOdFUDQV6AFT8TK0cVH4KKeylO7BnBeVI6c5qObmOOSyYnhuruInJBrRb+rJqHxd3+dF7ZHafRAj4A==",
       "dependencies": {
         "@aws-sdk/client-lambda": "3.43.0",
         "@aws-sdk/client-ssm": "3.43.0",
@@ -7138,9 +7140,9 @@
       }
     },
     "node_modules/@serverless-stack/resources": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/resources/-/resources-1.18.3.tgz",
-      "integrity": "sha512-gyx9pqBo+uLMIygdbiuRd3Sdg0hSyaYbb1J6KP52iHzPR/6EjFxloJIabY88Y4cU7MB6Q5AdJ52opnYvymT9sQ==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/resources/-/resources-1.18.4.tgz",
+      "integrity": "sha512-rryGU74daEYut9ZCvji0SjanKnLEgGAjzQj3LiFCZ6xzty+stR7cJtbfbk/M0rta/tG8vjzVr2xZ/qLUYjdJqg==",
       "dev": true,
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2-alpha": "2.50.0-alpha.0",
@@ -7148,7 +7150,7 @@
         "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.50.0-alpha.0",
         "@aws-cdk/aws-appsync-alpha": "2.50.0-alpha.0",
         "@aws-sdk/client-codebuild": "^3.169.0",
-        "@serverless-stack/core": "1.18.3",
+        "@serverless-stack/core": "1.18.4",
         "archiver": "^5.3.0",
         "aws-cdk-lib": "2.50.0",
         "chalk": "^4.1.0",
@@ -7269,6 +7271,11 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -8343,6 +8350,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -8973,7 +8981,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -9099,6 +9108,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -9621,7 +9631,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/concordance": {
       "version": "5.0.4",
@@ -9672,9 +9683,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.169",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.169.tgz",
-      "integrity": "sha512-tFZhYBFZr7yg/HX0FT8iyQZvuGdcrSwXgSh7+JkdSkqbNDQylWJuAfIjg+CsfPR7J2JxwUDClN07Sc3LMDtSGQ==",
+      "version": "10.1.170",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.170.tgz",
+      "integrity": "sha512-kFEwQ/iqn/DzpHR+BJcn6cQjGaPwmICeaPUjjbPgq7GL7i8twcyRXb1337NdVsnxBQT1g8AOFdWh20LTomGLUw==",
       "engines": {
         "node": ">= 14.17.0"
       }
@@ -10991,9 +11002,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "39.6.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.3.tgz",
-      "integrity": "sha512-omyUBTh0Wvn7NI62PI3zgfTHb5EUvbq0NFdMHw5kgkhgwVFKY50MOwpv1GDQVD7aL307463kZZmrEWSM8o1DOA==",
+      "version": "39.6.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.4.tgz",
+      "integrity": "sha512-fskvdLCfwmPjHb6e+xNGDtGgbF8X7cDwMtVLAP2WwSf9Htrx68OAx31BESBM1FAwsN2HTQyYQq7m4aW4Q4Nlag==",
       "dev": true,
       "dependencies": {
         "@es-joy/jsdoccomment": "~0.36.1",
@@ -11776,6 +11787,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -12073,7 +12085,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -12338,6 +12351,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -13125,6 +13139,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -13273,9 +13288,9 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
-      "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -13288,24 +13303,24 @@
       "dev": true
     },
     "node_modules/lint-staged": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.3.tgz",
-      "integrity": "sha512-9hmrwSCFroTSYLjflGI8Uk+GWAwMB4OlpU4bMJEAT5d/llQwtYKoim4bLOyLCuWFAhWEupE0vkIFqtw/WIsPug==",
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.4.tgz",
+      "integrity": "sha512-HxlHCXoYRsq9QCby5wFozmZW00hMs/9e3l+/dz6Qr8Kle4UH0kJTdABAbqhzG+3pcG6QjL9kz7NgGBfph+a5dw==",
       "dev": true,
       "dependencies": {
         "cli-truncate": "^3.1.0",
-        "colorette": "^2.0.17",
-        "commander": "^9.3.0",
+        "colorette": "^2.0.19",
+        "commander": "^9.4.1",
         "debug": "^4.3.4",
         "execa": "^6.1.0",
-        "lilconfig": "2.0.5",
-        "listr2": "^4.0.5",
+        "lilconfig": "2.0.6",
+        "listr2": "^5.0.5",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "object-inspect": "^1.12.2",
         "pidtree": "^0.6.0",
         "string-argv": "^0.3.1",
-        "yaml": "^2.1.1"
+        "yaml": "^2.1.3"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -13341,22 +13356,22 @@
       "dev": true
     },
     "node_modules/listr2": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
-      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.5.tgz",
+      "integrity": "sha512-DpBel6fczu7oQKTXMekeprc0o3XDgGMkD7JNYyX+X0xbwK+xgrx9dcyKoXKqpLSUvAWfmoePS7kavniOcq3r4w==",
       "dev": true,
       "dependencies": {
         "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.16",
+        "colorette": "^2.0.19",
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
         "rfdc": "^1.3.0",
-        "rxjs": "^7.5.5",
+        "rxjs": "^7.5.6",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^14.13.1 || >=16.0.0"
       },
       "peerDependencies": {
         "enquirer": ">= 2.3.0 < 3"
@@ -13885,6 +13900,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -13902,9 +13918,9 @@
       }
     },
     "node_modules/minipass": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
-      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -14677,6 +14693,21 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "dependencies": {
+        "@types/retry": "0.12.1",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15562,7 +15593,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -16825,6 +16855,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -17192,6 +17223,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
       "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
+      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -22713,7 +22745,8 @@
     "@balena/dockerignore": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
-      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "dev": true
     },
     "@es-joy/jsdoccomment": {
       "version": "0.36.1",
@@ -22991,14 +23024,14 @@
       }
     },
     "@serverless-stack/cli": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/cli/-/cli-1.18.3.tgz",
-      "integrity": "sha512-/FmccyyUFgvmv7VKeY7hZW97KjH2MK2S6ElxRZjhotmONO6YC7SlyZsv4eBS6Ge91Xsak5BICV7niyjKcvbebg==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/cli/-/cli-1.18.4.tgz",
+      "integrity": "sha512-eEG3brlbF/ptIo/s69Hcrn185CVkLWHpmtOmere7+lMPkmy1vxNhWIUuic+LNG0yweK+sg4uMVipREyvwblNDQ==",
       "dev": true,
       "requires": {
         "@aws-cdk/aws-apigatewayv2-alpha": "2.50.0-alpha.0",
-        "@serverless-stack/core": "1.18.3",
-        "@serverless-stack/resources": "1.18.3",
+        "@serverless-stack/core": "1.18.4",
+        "@serverless-stack/resources": "1.18.4",
         "aws-cdk": "2.50.0",
         "aws-cdk-lib": "2.50.0",
         "aws-sdk": "^2.1110.0",
@@ -23018,9 +23051,9 @@
       }
     },
     "@serverless-stack/core": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/core/-/core-1.18.3.tgz",
-      "integrity": "sha512-oQTTgh2iajNNX9riZ340jOF/rWRQgSDLAr0WfuySysC9VmvLMtPwHVcWuSDvmb0pG/fkrpMErNRFtE3IvSQ/hA==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/core/-/core-1.18.4.tgz",
+      "integrity": "sha512-j6eoGoZbADbLsc95ZJZQ3nWkXqdlfayx1xEWE0UpFjxthKUi8qZUONd7NOEyTHiR0yYV1NrANcWur2alvn+vlA==",
       "dev": true,
       "requires": {
         "@pothos/core": "^3.11.0",
@@ -23063,9 +23096,9 @@
       }
     },
     "@serverless-stack/node": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/node/-/node-1.18.3.tgz",
-      "integrity": "sha512-bF06TCWoPikgFCgPWswzd6F8OliCsuN/62LmsSKnTIAP9aczPhL/g59hD2XLR/jtOQ6AlWyjYCplhlETdWBSQA==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/node/-/node-1.18.4.tgz",
+      "integrity": "sha512-j2/Iolg9HOdFUDQV6AFT8TK0cVH4KKeylO7BnBeVI6c5qObmOOSyYnhuruInJBrRb+rJqHxd3+dF7ZHafRAj4A==",
       "requires": {
         "@aws-sdk/client-lambda": "3.43.0",
         "@aws-sdk/client-ssm": "3.43.0",
@@ -23080,9 +23113,9 @@
       }
     },
     "@serverless-stack/resources": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@serverless-stack/resources/-/resources-1.18.3.tgz",
-      "integrity": "sha512-gyx9pqBo+uLMIygdbiuRd3Sdg0hSyaYbb1J6KP52iHzPR/6EjFxloJIabY88Y4cU7MB6Q5AdJ52opnYvymT9sQ==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@serverless-stack/resources/-/resources-1.18.4.tgz",
+      "integrity": "sha512-rryGU74daEYut9ZCvji0SjanKnLEgGAjzQj3LiFCZ6xzty+stR7cJtbfbk/M0rta/tG8vjzVr2xZ/qLUYjdJqg==",
       "dev": true,
       "requires": {
         "@aws-cdk/aws-apigatewayv2-alpha": "2.50.0-alpha.0",
@@ -23090,7 +23123,7 @@
         "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.50.0-alpha.0",
         "@aws-cdk/aws-appsync-alpha": "2.50.0-alpha.0",
         "@aws-sdk/client-codebuild": "^3.169.0",
-        "@serverless-stack/core": "1.18.3",
+        "@serverless-stack/core": "1.18.4",
         "archiver": "^5.3.0",
         "aws-cdk-lib": "2.50.0",
         "chalk": "^4.1.0",
@@ -23206,6 +23239,11 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -23619,6 +23657,7 @@
         "ava": "^4.3.3",
         "multiformats": "^10.0.2",
         "nanoid": "^4.0.0",
+        "p-retry": "^5.1.2",
         "testcontainers": "^8.13.0"
       }
     },
@@ -24068,7 +24107,8 @@
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
     },
     "atomically": {
       "version": "1.7.0",
@@ -24495,7 +24535,8 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
@@ -24585,6 +24626,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -24989,7 +25031,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "concordance": {
       "version": "5.0.4",
@@ -25031,9 +25074,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.169",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.169.tgz",
-      "integrity": "sha512-tFZhYBFZr7yg/HX0FT8iyQZvuGdcrSwXgSh7+JkdSkqbNDQylWJuAfIjg+CsfPR7J2JxwUDClN07Sc3LMDtSGQ=="
+      "version": "10.1.170",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.170.tgz",
+      "integrity": "sha512-kFEwQ/iqn/DzpHR+BJcn6cQjGaPwmICeaPUjjbPgq7GL7i8twcyRXb1337NdVsnxBQT1g8AOFdWh20LTomGLUw=="
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -25999,9 +26042,9 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "39.6.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.3.tgz",
-      "integrity": "sha512-omyUBTh0Wvn7NI62PI3zgfTHb5EUvbq0NFdMHw5kgkhgwVFKY50MOwpv1GDQVD7aL307463kZZmrEWSM8o1DOA==",
+      "version": "39.6.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.4.tgz",
+      "integrity": "sha512-fskvdLCfwmPjHb6e+xNGDtGgbF8X7cDwMtVLAP2WwSf9Htrx68OAx31BESBM1FAwsN2HTQyYQq7m4aW4Q4Nlag==",
       "dev": true,
       "requires": {
         "@es-joy/jsdoccomment": "~0.36.1",
@@ -26502,6 +26545,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -26721,7 +26765,8 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -26926,7 +26971,8 @@
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true
     },
     "ignore-by-default": {
       "version": "2.1.0",
@@ -27454,6 +27500,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
@@ -27563,9 +27610,9 @@
       }
     },
     "lilconfig": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
-      "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
       "dev": true
     },
     "lines-and-columns": {
@@ -27575,24 +27622,24 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.3.tgz",
-      "integrity": "sha512-9hmrwSCFroTSYLjflGI8Uk+GWAwMB4OlpU4bMJEAT5d/llQwtYKoim4bLOyLCuWFAhWEupE0vkIFqtw/WIsPug==",
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.4.tgz",
+      "integrity": "sha512-HxlHCXoYRsq9QCby5wFozmZW00hMs/9e3l+/dz6Qr8Kle4UH0kJTdABAbqhzG+3pcG6QjL9kz7NgGBfph+a5dw==",
       "dev": true,
       "requires": {
         "cli-truncate": "^3.1.0",
-        "colorette": "^2.0.17",
-        "commander": "^9.3.0",
+        "colorette": "^2.0.19",
+        "commander": "^9.4.1",
         "debug": "^4.3.4",
         "execa": "^6.1.0",
-        "lilconfig": "2.0.5",
-        "listr2": "^4.0.5",
+        "lilconfig": "2.0.6",
+        "listr2": "^5.0.5",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "object-inspect": "^1.12.2",
         "pidtree": "^0.6.0",
         "string-argv": "^0.3.1",
-        "yaml": "^2.1.1"
+        "yaml": "^2.1.3"
       },
       "dependencies": {
         "debug": {
@@ -27613,17 +27660,17 @@
       }
     },
     "listr2": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
-      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.5.tgz",
+      "integrity": "sha512-DpBel6fczu7oQKTXMekeprc0o3XDgGMkD7JNYyX+X0xbwK+xgrx9dcyKoXKqpLSUvAWfmoePS7kavniOcq3r4w==",
       "dev": true,
       "requires": {
         "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.16",
+        "colorette": "^2.0.19",
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
         "rfdc": "^1.3.0",
-        "rxjs": "^7.5.5",
+        "rxjs": "^7.5.6",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       },
@@ -28017,6 +28064,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -28028,9 +28076,9 @@
       "dev": true
     },
     "minipass": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
-      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
@@ -28569,6 +28617,15 @@
       "dev": true,
       "requires": {
         "aggregate-error": "^3.0.0"
+      }
+    },
+    "p-retry": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "requires": {
+        "@types/retry": "0.12.1",
+        "retry": "^0.13.1"
       }
     },
     "p-timeout": {
@@ -29186,8 +29243,7 @@
     "retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "reusify": {
       "version": "1.0.4",
@@ -30145,7 +30201,8 @@
     "universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -30432,7 +30489,8 @@
     "yaml": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
-      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg=="
+      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
+      "dev": true
     },
     "yargs": {
       "version": "15.4.1",


### PR DESCRIPTION
Write mapping (data CID -> car CID) into Dudewhere. It includes:
- bucket abstraction layer similar to what we have for carpark
- `upload/add` updated to write entries into Dudewhere by relying on bucket abstraction layer
  - doing same retry approach as we do in CF hosted API

Questions:
- wondering if we should just use dudewhere naming instead of long `data-cid-to-car-cid-store`. We will lose readability, but maybe we want same pattern as calling `carpark` everywhere. Thoughts?

Closes #39 