### PR TITLE
feat: share table schema between infra and test code

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@ipld/car": "^5.0.1",
     "@ipld/dag-ucan": "^2.0.1",
+    "@serverless-stack/resources": "*",
     "@types/aws-lambda": "^8.10.108",
     "@ucanto/core": "^3.0.2",
     "@web-std/blob": "3.0.4",

--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "type": "module",
   "scripts": {
-    "test": "ava --verbose --timeout=60s --serial **/*.test.js"
+    "test": "ava --verbose --timeout=60s **/*.test.js"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.211.0",

--- a/api/tables/index.js
+++ b/api/tables/index.js
@@ -1,9 +1,14 @@
+/** @typedef {import('@aws-sdk/client-dynamodb').CreateTableCommandInput} CreateTableCommandInput */
+/** @typedef {import('@serverless-stack/resources').TableProps} TableProps */
+
 /**
- * Convert SST Table spec to DynamoDB CreateTable command config
+ * Convert SST TableProps to DynamoDB `CreateTableCommandInput` config
  *
- * @param {{fields: Record<string,string>, primaryIndex: { partitionKey: string, sortKey: string}}} config
+ * @param {TableProps} props
+ * @returns {Pick<CreateTableCommandInput, 'AttributeDefinitions' | 'KeySchema'>}
  */
 export function dynamoDBTableConfig ({ fields, primaryIndex }) {
+  if (!primaryIndex || !fields) throw new Error('Expected primaryIndex and fields on TableProps')
   const attributes = Object.values(primaryIndex)
   const AttributeDefinitions = Object.entries(fields)
     .filter(([k]) => attributes.includes(k)) // 'The number of attributes in key schema must match the number of attributes defined in attribute definitions'
@@ -25,7 +30,8 @@ export function dynamoDBTableConfig ({ fields, primaryIndex }) {
   }
 }
 
-export const storeTableSchema = {
+/** @type TableProps */
+export const storeTableProps = {
   fields: {
     uploaderDID: 'string',
     payloadCID: 'string',
@@ -38,7 +44,8 @@ export const storeTableSchema = {
   primaryIndex: { partitionKey: 'uploaderDID', sortKey: 'payloadCID' },
 }
 
-export const uploadTableSchema = {
+/** @type TableProps */
+export const uploadTableProps = {
   fields: {
     uploaderDID: 'string',
     dataCID: 'string', // root CID

--- a/api/tables/index.js
+++ b/api/tables/index.js
@@ -1,0 +1,50 @@
+/**
+ * Convert SST Table spec to DynamoDB CreateTable command config
+ *
+ * @param {{fields: Record<string,string>, primaryIndex: { partitionKey: string, sortKey: string}}} config
+ */
+export function dynamoDBTableConfig ({ fields, primaryIndex }) {
+  const attributes = Object.values(primaryIndex)
+  const AttributeDefinitions = Object.entries(fields)
+    .filter(([k]) => attributes.includes(k)) // 'The number of attributes in key schema must match the number of attributes defined in attribute definitions'
+    .map(([k, v]) => ({
+      AttributeName: k,
+      AttributeType: v[0].toUpperCase()
+    }))
+  const KeySchema = [
+    { AttributeName: primaryIndex.partitionKey, KeyType: 'HASH' }
+  ]
+  if (primaryIndex.sortKey) {
+    KeySchema.push(
+      { AttributeName: primaryIndex.sortKey, KeyType: 'RANGE' }
+    )
+  }
+  return {
+    AttributeDefinitions,
+    KeySchema
+  }
+}
+
+export const storeTableSchema = {
+  fields: {
+    uploaderDID: 'string',
+    payloadCID: 'string',
+    applicationDID: 'string',
+    origin: 'string',
+    size: 'number',
+    proof: 'string',
+    uploadedAt: 'string',
+  },
+  primaryIndex: { partitionKey: 'uploaderDID', sortKey: 'payloadCID' },
+}
+
+export const uploadTableSchema = {
+  fields: {
+    uploaderDID: 'string',
+    dataCID: 'string', // root CID
+    carCID: 'string', // shard CID
+    sk: 'string', // 'dataCID#carCID' used to guarantee uniqueness
+    uploadedAt: 'string',
+  },
+  primaryIndex: { partitionKey: 'uploaderDID', sortKey: 'sk' },
+}

--- a/api/test/service/store.test.js
+++ b/api/test/service/store.test.js
@@ -10,7 +10,7 @@ import * as StoreCapabilities from '@web3-storage/access/capabilities/store'
 import { base64pad } from 'multiformats/bases/base64'
 import { getClientConnection, createSpace } from '../helpers/ucanto.js'
 import { createS3, createBucket, createDynamodDb, createAccessServer } from '../utils.js'
-import { dynamoDBTableConfig, storeTableSchema } from '../../tables/index.js'
+import { dynamoDBTableConfig, storeTableProps } from '../../tables/index.js'
 
 /**
  * @typedef {import('../../service/types').StoreListResult} StoreListResult
@@ -494,7 +494,7 @@ async function createDynamoStoreTable(dynamo) {
   // TODO: see in pickup Document DB wrapper
   await dynamo.send(new CreateTableCommand({
     TableName: tableName,
-    ...dynamoDBTableConfig(storeTableSchema),
+    ...dynamoDBTableConfig(storeTableProps),
     ProvisionedThroughput: {
       ReadCapacityUnits: 1,
       WriteCapacityUnits: 1

--- a/api/test/service/store.test.js
+++ b/api/test/service/store.test.js
@@ -10,6 +10,7 @@ import * as StoreCapabilities from '@web3-storage/access/capabilities/store'
 import { base64pad } from 'multiformats/bases/base64'
 import { getClientConnection, createSpace } from '../helpers/ucanto.js'
 import { createS3, createBucket, createDynamodDb, createAccessServer } from '../utils.js'
+import { dynamoDBTableConfig, storeTableSchema } from '../../tables/index.js'
 
 /**
  * @typedef {import('../../service/types').StoreListResult} StoreListResult
@@ -493,14 +494,7 @@ async function createDynamoStoreTable(dynamo) {
   // TODO: see in pickup Document DB wrapper
   await dynamo.send(new CreateTableCommand({
     TableName: tableName,
-    AttributeDefinitions: [
-      { AttributeName: 'uploaderDID', AttributeType: 'S' },
-      { AttributeName: 'payloadCID', AttributeType: 'S' }
-    ],
-    KeySchema: [
-      { AttributeName: 'uploaderDID', KeyType: 'HASH' },
-      { AttributeName: 'payloadCID', KeyType: 'RANGE' },
-    ],
+    ...dynamoDBTableConfig(storeTableSchema),
     ProvisionedThroughput: {
       ReadCapacityUnits: 1,
       WriteCapacityUnits: 1

--- a/api/test/service/upload.test.js
+++ b/api/test/service/upload.test.js
@@ -10,6 +10,7 @@ import { BATCH_MAX_SAFE_LIMIT } from '../../tables/upload.js'
 import { createS3, createBucket, createAccessServer, createDynamodDb } from '../utils.js'
 import { randomCAR } from '../helpers/random.js'
 import { getClientConnection, createSpace } from '../helpers/ucanto.js'
+import { dynamoDBTableConfig, uploadTableSchema } from '../../tables/index.js'
 
 /**
  * @typedef {import('@ucanto/server')} Server
@@ -468,14 +469,7 @@ async function prepareResources (dynamoClient, s3Client) {
 
   await dynamo.send(new CreateTableCommand({
     TableName: tableName,
-    AttributeDefinitions: [
-      { AttributeName: 'uploaderDID', AttributeType: 'S' },
-      { AttributeName: 'sk', AttributeType: 'S' }
-    ],
-    KeySchema: [
-      { AttributeName: 'uploaderDID', KeyType: 'HASH' },
-      { AttributeName: 'sk', KeyType: 'RANGE' },
-    ],
+    ...dynamoDBTableConfig(uploadTableSchema),
     ProvisionedThroughput: {
       ReadCapacityUnits: 1,
       WriteCapacityUnits: 1

--- a/api/test/service/upload.test.js
+++ b/api/test/service/upload.test.js
@@ -10,7 +10,7 @@ import { BATCH_MAX_SAFE_LIMIT } from '../../tables/upload.js'
 import { createS3, createBucket, createAccessServer, createDynamodDb } from '../utils.js'
 import { randomCAR } from '../helpers/random.js'
 import { getClientConnection, createSpace } from '../helpers/ucanto.js'
-import { dynamoDBTableConfig, uploadTableSchema } from '../../tables/index.js'
+import { dynamoDBTableConfig, uploadTableProps } from '../../tables/index.js'
 
 /**
  * @typedef {import('@ucanto/server')} Server
@@ -469,7 +469,7 @@ async function prepareResources (dynamoClient, s3Client) {
 
   await dynamo.send(new CreateTableCommand({
     TableName: tableName,
-    ...dynamoDBTableConfig(uploadTableSchema),
+    ...dynamoDBTableConfig(uploadTableProps),
     ProvisionedThroughput: {
       ReadCapacityUnits: 1,
       WriteCapacityUnits: 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
       "devDependencies": {
         "@ipld/car": "^5.0.1",
         "@ipld/dag-ucan": "^2.0.1",
+        "@serverless-stack/resources": "*",
         "@types/aws-lambda": "^8.10.108",
         "@ucanto/core": "^3.0.2",
         "@web-std/blob": "3.0.4",
@@ -20888,6 +20889,7 @@
         "@ipld/car": "^5.0.1",
         "@ipld/dag-ucan": "^2.0.1",
         "@serverless-stack/node": "^1.18.2",
+        "@serverless-stack/resources": "*",
         "@types/aws-lambda": "^8.10.108",
         "@ucanto/core": "^3.0.2",
         "@ucanto/interface": "^3.0.1",

--- a/stacks/api-stack.js
+++ b/stacks/api-stack.js
@@ -5,7 +5,7 @@ import {
   Table
 } from '@serverless-stack/resources'
 
-import { storeTableSchema, uploadTableSchema } from '../api/tables/index.js'
+import { storeTableProps, uploadTableProps } from '../api/tables/index.js'
 import { getConfig, getCustomDomain, getApiPackageJson, getGitInfo } from './config.js'
 
 /**
@@ -23,7 +23,7 @@ export function ApiStack({ stack }) {
    * This is used by the store/* service capabilities.
    */
    const storeTable = new Table(stack, 'store', {
-    ...storeTableSchema,
+    ...storeTableProps,
     ...stackConfig.tableConfig,
   })
   
@@ -40,7 +40,7 @@ export function ApiStack({ stack }) {
    * This is used by the upload/* capabilities.
    */
    const uploadTable = new Table(stack, 'upload', {
-    ...uploadTableSchema,
+    ...uploadTableProps,
     ...stackConfig.tableConfig,
   })
 

--- a/stacks/api-stack.js
+++ b/stacks/api-stack.js
@@ -5,6 +5,7 @@ import {
   Table
 } from '@serverless-stack/resources'
 
+import { storeTableSchema, uploadTableSchema } from '../api/tables/index.js'
 import { getConfig, getCustomDomain, getApiPackageJson, getGitInfo } from './config.js'
 
 /**
@@ -22,16 +23,7 @@ export function ApiStack({ stack }) {
    * This is used by the store/* service capabilities.
    */
    const storeTable = new Table(stack, 'store', {
-    fields: {
-      uploaderDID: 'string',
-      payloadCID: 'string',
-      applicationDID: 'string',
-      origin: 'string',
-      size: 'number',
-      proof: 'string',
-      uploadedAt: 'string',
-    },
-    primaryIndex: { partitionKey: 'uploaderDID', sortKey: 'payloadCID' },
+    ...storeTableSchema,
     ...stackConfig.tableConfig,
   })
   
@@ -48,14 +40,7 @@ export function ApiStack({ stack }) {
    * This is used by the upload/* capabilities.
    */
    const uploadTable = new Table(stack, 'upload', {
-    fields: {
-      uploaderDID: 'string',
-      dataCID: 'string', // root CID
-      carCID: 'string', // shard CID
-      sk: 'string', // 'dataCID#carCID' used to guarantee uniqueness
-      uploadedAt: 'string',
-    },
-    primaryIndex: { partitionKey: 'uploaderDID', sortKey: 'sk' },
+    ...uploadTableSchema,
     ...stackConfig.tableConfig,
   })
 


### PR DESCRIPTION
pull the table definitions into api/tables/index.js and reuse them in both infra and test code.

provides `dynamoDBTableConfig` fn to convert SST table definition to DynamoDB CreateTableCommandInput

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>