### PR TITLE
feat!: update table schema

### DIFF
--- a/api/service/store/add.js
+++ b/api/service/store/add.js
@@ -18,31 +18,29 @@ export function storeAddProvider(context) {
     async ({ capability, invocation }) => {
       const { link, origin, size } = capability.nb
       const space = Server.DID.parse(capability.with).did()
-      const car = link.toString()
-      const agent = invocation.issuer.did()
-      const ucan = invocation.cid.toString() 
+      const issuer = invocation.issuer.did()
       const [
         verified,
         carIsLinkedToAccount,
         carExists
       ] = await Promise.all([
         context.access.verifyInvocation(invocation),
-        context.storeTable.exists(space, car),
-        context.carStoreBucket.has(car)
+        context.storeTable.exists(space, link),
+        context.carStoreBucket.has(link.toString())
       ])
 
       if (!verified) {
-        return new Server.Failure(`${agent} is not delegated capability ${Store.add.can} on ${space}`)
+        return new Server.Failure(`${issuer} is not delegated capability ${Store.add.can} on ${space}`)
       }
 
       if (!carIsLinkedToAccount) {
         await context.storeTable.insert({
           space,
-          car,
+          link,
           size,
-          origin: origin?.toString(),
-          agent,
-          ucan
+          origin,
+          issuer,
+          invocation: invocation.cid,
         })
       }
 

--- a/api/service/store/list.js
+++ b/api/service/store/list.js
@@ -22,7 +22,7 @@ export function storeListProvider(context) {
       // Only use capability account for now to check if account is registered.
       // This must change to access account/info!!
       // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
-      const space = capability.with
+      const space = Server.DID.parse(capability.with).did()
 
       return await context.storeTable.list(space, {
         size,

--- a/api/service/store/list.js
+++ b/api/service/store/list.js
@@ -22,9 +22,9 @@ export function storeListProvider(context) {
       // Only use capability account for now to check if account is registered.
       // This must change to access account/info!!
       // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
-      const account = capability.with
+      const space = capability.with
 
-      return await context.storeTable.list(account, {
+      return await context.storeTable.list(space, {
         size,
         cursor
       })

--- a/api/service/store/remove.js
+++ b/api/service/store/remove.js
@@ -19,9 +19,9 @@ export function storeRemoveProvider(context) {
       // Only use capability account for now to check if account is registered.
       // This must change to access account/info!!
       // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
-      const space = capability.with
+      const space = Server.DID.parse(capability.with).did()
 
-      await context.storeTable.remove(space, link.toString())
+      await context.storeTable.remove(space, link)
     }
   )
 }

--- a/api/service/store/remove.js
+++ b/api/service/store/remove.js
@@ -19,9 +19,9 @@ export function storeRemoveProvider(context) {
       // Only use capability account for now to check if account is registered.
       // This must change to access account/info!!
       // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
-      const account = capability.with
+      const space = capability.with
 
-      await context.storeTable.remove(account, link.toString())
+      await context.storeTable.remove(space, link.toString())
     }
   )
 }

--- a/api/service/types.ts
+++ b/api/service/types.ts
@@ -46,17 +46,17 @@ export interface CarStoreBucket {
 }
 
 export interface StoreTable {
-  exists: (uploaderDID: string, payloadCID: string) => Promise<boolean>
+  exists: (space: string, car: string) => Promise<boolean>
   insert: (item: StoreItemInput) => Promise<StoreItemOutput>
-  remove: (uploaderDID: string, payloadCID: string) => Promise<void>
-  list: (uploaderDID: string, options?: ListOptions) => Promise<ListResponse<StoreListResult>>
+  remove: (space: string, car: string) => Promise<void>
+  list: (space: string, options?: ListOptions) => Promise<ListResponse<StoreListResult>>
 }
 
 export interface UploadTable {
-  exists: (uploaderDID: string, dataCID: string) => Promise<boolean>
-  insert: (uploaderDID: string, item: UploadItemInput) => Promise<UploadItemOutput[]>
-  remove: (uploaderDID: string, dataCID: string) => Promise<void>
-  list: (uploaderDID: string, options?: ListOptions) => Promise<ListResponse<UploadItemOutput>>
+  exists: (space: string, root: string) => Promise<boolean>
+  insert: (item: UploadItemInput) => Promise<UploadItemOutput[]>
+  remove: (space: string, root: string) => Promise<void>
+  list: (space: string, options?: ListOptions) => Promise<ListResponse<UploadItemOutput>>
 }
 
 export interface Signer {
@@ -64,21 +64,16 @@ export interface Signer {
 }
 
 export interface StoreItemInput {
-  uploaderDID: string,
-  link: string,
-  origin?: string,
+  space: string,
+  car: string,
   size: number,
-  proof: string,
+  origin?: string,
+  agent: string,
+  ucan: string,
 }
 
-export interface StoreItemOutput {
-  uploaderDID: string,
-  payloadCID: string,
-  applicationDID: string,
-  origin: string,
-  size: number,
-  proof: string,
-  uploadedAt: string,
+export interface StoreItemOutput extends StoreItemInput {
+  insertedAt: string,
 }
 
 export interface StoreAddResult {
@@ -89,16 +84,16 @@ export interface StoreAddResult {
   headers?: Record<string, string>
 }
 
-export type ListOptions = {
+export interface ListOptions {
   size?: number,
   cursor?: string
 }
 
 export interface StoreListResult {
-  payloadCID: string
-  origin?: string
+  car: string
   size: number
-  uploadedAt: string
+  origin?: string
+  insertedAt: string
 }
 
 export interface ListResponse<R> {
@@ -107,16 +102,20 @@ export interface ListResponse<R> {
   results: R[]
 }
 
-export interface UploadItemInput {
-  dataCID: string,
-  carCIDs: string[]
+interface UploadItemBase {
+  space: string
+  root: string,
+  agent: string,
+  ucan: string,  
 }
 
-export interface UploadItemOutput {
-  uploaderDID: string,
-  dataCID: string,
-  carCID: string,
-  uploadedAt: string,
+export interface UploadItemInput extends UploadItemBase {
+  shards: string[]
+}
+
+export interface UploadItemOutput extends UploadItemBase {
+  shard: string,
+  insertedAt: string,
 }
 
 export interface AccessClient {

--- a/api/service/upload/add.js
+++ b/api/service/upload/add.js
@@ -20,17 +20,15 @@ export function uploadAddProvider(context) {
       // Only use capability account for now to check if account is registered.
       // This must change to access account/info!!
       // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
-      const space = capability.with
+      const space = Server.DID.parse(capability.with).did()
 
       const res = await context.uploadTable.insert({
         space,
-        root: root.toString(),
-        shards: shards?.map(s => s.toString()) || [],
-        agent: invocation.issuer.did(),
-        ucan: invocation.cid.toString()
+        root,
+        shards,
+        issuer: invocation.issuer.did(),
+        invocation: invocation.cid
       })
-
-      // TODO: write mapping to DUDEWHERE
 
       return res
   })

--- a/api/service/upload/add.js
+++ b/api/service/upload/add.js
@@ -14,17 +14,20 @@ import * as Upload from '@web3-storage/access/capabilities/upload'
 export function uploadAddProvider(context) {
   return Server.provide(
     Upload.add,
-    async ({ capability }) => {
+    async ({ capability, invocation }) => {
       const { root, shards } = capability.nb
 
       // Only use capability account for now to check if account is registered.
       // This must change to access account/info!!
       // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
-      const account = capability.with
+      const space = capability.with
 
-      const res = await context.uploadTable.insert(account, {
-        dataCID: root.toString(),
-        carCIDs: shards?.map(s => s.toString()) || []
+      const res = await context.uploadTable.insert({
+        space,
+        root: root.toString(),
+        shards: shards?.map(s => s.toString()) || [],
+        agent: invocation.issuer.did(),
+        ucan: invocation.cid.toString()
       })
 
       // TODO: write mapping to DUDEWHERE

--- a/api/service/upload/list.js
+++ b/api/service/upload/list.js
@@ -21,9 +21,9 @@ export function uploadListProvider(context) {
       // Only use capability account for now to check if account is registered.
       // This must change to access account/info!!
       // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
-      const account = capability.with
+      const space = capability.with
 
-      return await context.uploadTable.list(account, {
+      return await context.uploadTable.list(space, {
         size,
         cursor
       })

--- a/api/service/upload/list.js
+++ b/api/service/upload/list.js
@@ -21,7 +21,7 @@ export function uploadListProvider(context) {
       // Only use capability account for now to check if account is registered.
       // This must change to access account/info!!
       // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
-      const space = capability.with
+      const space = Server.DID.parse(capability.with).did()
 
       return await context.uploadTable.list(space, {
         size,

--- a/api/service/upload/remove.js
+++ b/api/service/upload/remove.js
@@ -19,8 +19,8 @@ export function uploadRemoveProvider(context) {
       // Only use capability account for now to check if account is registered.
       // This must change to access account/info!!
       // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
-      const space = capability.with
+      const space = Server.DID.parse(capability.with).did()
 
-      await context.uploadTable.remove(space, root.toString())
+      await context.uploadTable.remove(space, root)
   })
 }

--- a/api/service/upload/remove.js
+++ b/api/service/upload/remove.js
@@ -19,8 +19,8 @@ export function uploadRemoveProvider(context) {
       // Only use capability account for now to check if account is registered.
       // This must change to access account/info!!
       // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
-      const account = capability.with
+      const space = capability.with
 
-      await context.uploadTable.remove(account, root.toString())
+      await context.uploadTable.remove(space, root.toString())
   })
 }

--- a/api/tables/index.js
+++ b/api/tables/index.js
@@ -31,32 +31,6 @@ export function dynamoDBTableConfig ({ fields, primaryIndex }) {
 }
 
 /** @type TableProps */
-export const StoreTablePropsv0 = {
-  fields: {
-    uploaderDID: 'string',
-    payloadCID: 'string',
-    applicationDID: 'string',
-    origin: 'string',
-    size: 'number',
-    proof: 'string',
-    uploadedAt: 'string',
-  },
-  primaryIndex: { partitionKey: 'uploaderDID', sortKey: 'payloadCID' },
-}
-
-/** @type TableProps */
-export const uploadTablePropsV0 = {
-  fields: {
-    uploaderDID: 'string',
-    dataCID: 'string', // root CID
-    carCID: 'string', // shard CID
-    sk: 'string', // 'dataCID#carCID' used to guarantee uniqueness
-    uploadedAt: 'string',
-  },
-  primaryIndex: { partitionKey: 'uploaderDID', sortKey: 'sk' },
-}
-
-/** @type TableProps */
 export const storeTableProps = {
   fields: {
     space: 'string',        // `did:key:space`

--- a/api/tables/index.js
+++ b/api/tables/index.js
@@ -31,7 +31,7 @@ export function dynamoDBTableConfig ({ fields, primaryIndex }) {
 }
 
 /** @type TableProps */
-export const storeTableProps = {
+export const StoreTablePropsv0 = {
   fields: {
     uploaderDID: 'string',
     payloadCID: 'string',
@@ -45,7 +45,7 @@ export const storeTableProps = {
 }
 
 /** @type TableProps */
-export const uploadTableProps = {
+export const uploadTablePropsV0 = {
   fields: {
     uploaderDID: 'string',
     dataCID: 'string', // root CID
@@ -54,4 +54,34 @@ export const uploadTableProps = {
     uploadedAt: 'string',
   },
   primaryIndex: { partitionKey: 'uploaderDID', sortKey: 'sk' },
+}
+
+/** @type TableProps */
+export const storeTableProps = {
+  fields: {
+    space: 'string',        // `did:key:space`
+    car: 'string',          // `bagy...1`
+    size: 'number',         // `101`
+    origin: 'string',       // `bagy...0` (prev CAR CID. optional)
+    agent: 'string',        // `did:key:agent` (issuer of ucan)
+    ucan: 'string',         // `baf...ucan` (CID of invcation UCAN)
+    insertedAt: 'string',   // `2022-12-24T...`
+  },
+  // space + car must be unique to satisfy index constraint
+  primaryIndex: { partitionKey: 'space', sortKey: 'car' },
+}
+
+/** @type TableProps */
+export const uploadTableProps = {
+  fields: {
+    space: 'string',        // `did:key:space`
+    sk: 'string',           // `root#shard` + space must be unique for dynamo index constraint
+    root: 'string',         // `baf...x`
+    shard: 'string',        // `bagy...1
+    agent: 'string',        // `did:key:agent` (issuer of ucan)
+    ucan: 'string',         // `baf...ucan` (CID of invcation UCAN)
+    insertedAt: 'string',   // `2022-12-24T...`
+  },
+  // space + sk must be unique to satisfy index constraint
+  primaryIndex: { partitionKey: 'space', sortKey: 'sk' },
 }

--- a/api/tables/index.js
+++ b/api/tables/index.js
@@ -41,7 +41,7 @@ export const storeTableProps = {
     invocation: 'string',   // `baf...ucan` (CID of invcation UCAN)
     insertedAt: 'string',   // `2022-12-24T...`
   },
-  // space + car must be unique to satisfy index constraint
+  // space + link must be unique to satisfy index constraint
   primaryIndex: { partitionKey: 'space', sortKey: 'link' },
 }
 

--- a/api/tables/index.js
+++ b/api/tables/index.js
@@ -34,15 +34,15 @@ export function dynamoDBTableConfig ({ fields, primaryIndex }) {
 export const storeTableProps = {
   fields: {
     space: 'string',        // `did:key:space`
-    car: 'string',          // `bagy...1`
+    link: 'string',         // `bagy...1`
     size: 'number',         // `101`
     origin: 'string',       // `bagy...0` (prev CAR CID. optional)
-    agent: 'string',        // `did:key:agent` (issuer of ucan)
-    ucan: 'string',         // `baf...ucan` (CID of invcation UCAN)
+    issuer: 'string',       // `did:key:agent` (issuer of ucan)
+    invocation: 'string',   // `baf...ucan` (CID of invcation UCAN)
     insertedAt: 'string',   // `2022-12-24T...`
   },
   // space + car must be unique to satisfy index constraint
-  primaryIndex: { partitionKey: 'space', sortKey: 'car' },
+  primaryIndex: { partitionKey: 'space', sortKey: 'link' },
 }
 
 /** @type TableProps */
@@ -52,8 +52,8 @@ export const uploadTableProps = {
     sk: 'string',           // `root#shard` + space must be unique for dynamo index constraint
     root: 'string',         // `baf...x`
     shard: 'string',        // `bagy...1
-    agent: 'string',        // `did:key:agent` (issuer of ucan)
-    ucan: 'string',         // `baf...ucan` (CID of invcation UCAN)
+    issuer: 'string',       // `did:key:agent` (issuer of ucan)
+    invocation: 'string',   // `baf...ucan` (CID of invcation UCAN)
     insertedAt: 'string',   // `2022-12-24T...`
   },
   // space + sk must be unique to satisfy index constraint

--- a/api/tables/store.js
+++ b/api/tables/store.js
@@ -36,7 +36,7 @@ export function createStoreTable (region, tableName, options = {}) {
           space,
           link: link.toString()
         }),
-        AttributesToGet: ['uploaderDID'],
+        AttributesToGet: ['space'],
       })
   
       try {

--- a/api/test/service/store.test.js
+++ b/api/test/service/store.test.js
@@ -150,11 +150,11 @@ test('store/add returns done if already uploaded', async (t) => {
   const item = await getItemFromStoreTable(t.context.dynamoClient, tableName, spaceDid, link)
   t.like(item, {
     space: spaceDid,
-    car: link.toString(),
+    link: link.toString(),
     size: data.byteLength,
-    agent: alice.did(),
+    issuer: alice.did(),
   })
-  t.is(typeof item?.ucan, 'string')
+  t.is(typeof item?.invocation, 'string')
   t.is(typeof item?.insertedAt, 'string')
 })
 
@@ -393,7 +393,7 @@ test('store/list returns items previously stored by the user', async (t) => {
   links.reverse()
   let i = 0
   for (const entry of storeList.results) {
-    t.like(entry, { car: links[i].toString(), size: 5 })
+    t.like(entry, { link: links[i].toString(), size: 5 })
     i++
   }
 })
@@ -463,7 +463,7 @@ test('store/list can be paginated with custom size', async (t) => {
   links.reverse()
   let i = 0
   for (const entry of storeList) {
-    t.like(entry, { car: links[i].toString(), size: 5 })
+    t.like(entry, { link: links[i].toString(), size: 5 })
     i++
   }
 })
@@ -508,17 +508,17 @@ async function createDynamoStoreTable(dynamo) {
  * @param {import("@aws-sdk/client-dynamodb").DynamoDBClient} dynamo
  * @param {string} tableName
  * @param {`did:key:${string}`} space
- * @param {import('@ucanto/interface').Link<unknown, number, number, 0 | 1>} link
+ * @param {import('../../service/types').AnyLink} link
  */
 async function getItemFromStoreTable(dynamo, tableName, space, link) {
+  const item = {
+    space,
+    link: link.toString()
+  }
   const params = {
     TableName: tableName,
-    Key: marshall({
-      space,
-      car: link.toString(),
-    })
+    Key: marshall(item)
   }
-
   const response = await dynamo.send(new GetItemCommand(params))
   return response?.Item && unmarshall(response?.Item)
 }


### PR DESCRIPTION
Update the dynamoDB table schema to the following:

```js
/** @type TableProps */
export const storeTableProps = {
  fields: {
    space: 'string',        // `did:key:space`
    link: 'string',         // `bagy...1`
    size: 'number',         // `101`
    origin: 'string',       // `bagy...0` (prev CAR CID. optional)
    issuer: 'string',       // `did:key:agent` (issuer of ucan)
    invocation: 'string',   // `baf...ucan` (CID of invcation UCAN)
    insertedAt: 'string',   // `2022-12-24T...`
  },
  // space + link must be unique to satisfy index constraint
  primaryIndex: { partitionKey: 'space', sortKey: 'link' },
}

/** @type TableProps */
export const uploadTableProps = {
  fields: {
    space: 'string',        // `did:key:space`
    sk: 'string',           // `root#shard` + space must be unique for dynamo index constraint
    root: 'string',         // `baf...x`
    shard: 'string',        // `bagy...1
    issuer: 'string',       // `did:key:agent` (issuer of ucan)
    invocation: 'string',   // `baf...ucan` (CID of invcation UCAN)
    insertedAt: 'string',   // `2022-12-24T...`
  },
  // space + sk must be unique to satisfy index constraint
  primaryIndex: { partitionKey: 'space', sortKey: 'sk' },
}
```


- `uploaderDID` becomes `space`
- `payloadCID` becomes `link` to match the capability property
- `dataCID` becomes `root` to match the terminology in the upload-client.
- `carCID` becomes `shard` to match the terminology in the upload-client.
- adds `issuer` - the DID of the agent that issued the invocation
- adds `invocation` - the CID for the invocation ucan
- use `insertedAt` as all we are really capturing here is the time at which we inserted the doc into the db.
- align property names with the `upload-client`, our capability properties and the `access-api` data model
- ordered such the partitionKey and sortKey come first (not that it matters) and our accounting metadata last
- Fixed up types 🎉

...we can add more fields. Its a document db. The only fields we have to specify here are ones referenced in an index, but more fields are given here to give the flavour.

### References

- https://www.dynamodbguide.com/key-concepts
- w3 ucan caps https://github.com/web3-storage/w3protocol/blob/aef55e718eb8756ed95beb237780ef7125b3aace/packages/access/src/capabilities/upload.js#L37
- w3-access api db schema https://github.com/web3-storage/w3protocol/blob/cc0f4f44c06a5884c6af50cf739dad6164d8e468/packages/access-api/migrations/0000_create_spaces_table.sql
- upload-client naming https://github.com/web3-storage/w3protocol/blob/aef55e718eb8756ed95beb237780ef7125b3aace/packages/upload-client/README.md#uploadadd
- dynamodb data types https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes
- current w3up schema https://github.com/web3-storage/w3up/wiki/(current)-Ingestion-Database-Schema
- previous proposed schema update https://github.com/web3-storage/w3up/wiki/Desired-Ingestion-Schema

fixes #25 

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>