### PR TITLE
fix: env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,27 +51,27 @@ DID of the w3access service.
 
 URL of the w3access service.
 
-### `REPLICATOR_ACCESS_KEY_ID`
+### `R2_ACCESS_KEY_ID`
 
 Access key for S3 like cloud object storage to replicate content into.
 
-### `REPLICATOR_SECRET_ACCESS_KEY`
+### `R2_SECRET_ACCESS_KEY`
 
 Secret access key for S3 like cloud object storage to replicate content into.
 
-### `REPLICATOR_ENDPOINT`
+### `R2_ENDPOINT`
 
 Endpoint for S3 like cloud object storage to replicate content into.
 
-### `REPLICATOR_CAR_BUCKET_NAME`
+### `R2_CAR_BUCKET_NAME`
 
 Bucket name to replicate written CAR files.
 
-### `REPLICATOR_INDEX_BUCKET_NAME`
+### `R2_SATNAV_BUCKET_NAME`
 
 Bucket name to replicate written .idx files.
 
-### `REPLICATOR_DUDEWHERE_BUCKET_NAME`
+### `R2_DUDEWHERE_BUCKET_NAME`
 
 Bucket name to replicate root CID to car CIDs mapping.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Secret access key for S3 like cloud object storage to replicate content into.
 
 Endpoint for S3 like cloud object storage to replicate content into.
 
-### `R2_CAR_BUCKET_NAME`
+### `R2_CARPARK_BUCKET_NAME`
 
 Bucket name to replicate written CAR files.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,34 @@ DID of the w3access service.
 
 URL of the w3access service.
 
+### `REPLICATOR_ACCESS_KEY_ID`
+
+Access key for S3 like cloud object storage to replicate content into.
+
+### `REPLICATOR_SECRET_ACCESS_KEY`
+
+Secret access key for S3 like cloud object storage to replicate content into.
+
+### `REPLICATOR_ENDPOINT`
+
+Endpoint for S3 like cloud object storage to replicate content into.
+
+### `REPLICATOR_CAR_BUCKET_NAME`
+
+Bucket name to replicate written CAR files.
+
+### `REPLICATOR_INDEX_BUCKET_NAME`
+
+Bucket name to replicate written .idx files.
+
+### `REPLICATOR_DUDEWHERE_BUCKET_NAME`
+
+Bucket name to replicate root CID to car CIDs mapping.
+
+### `SENTRY_DSN`
+
+Data source name for Sentry application monitoring service.
+
 ### Secrets
 
 Set production secrets in aws SSM via [`sst secrets`](https://docs.sst.dev/config#sst-secrets). The region must be set to the one you deploy that stage to

--- a/api/functions/ucan-invocation-router.js
+++ b/api/functions/ucan-invocation-router.js
@@ -14,12 +14,12 @@ const AWS_SESSION_TOKEN = process.env.AWS_SESSION_TOKEN || ''
 const AWS_REGION = process.env.AWS_REGION || 'us-west-2'
 
 // Specified in SST environment
-const REPLICATOR_ACCESS_KEY_ID = process.env.REPLICATOR_ACCESS_KEY_ID || ''
-const REPLICATOR_SECRET_ACCESS_KEY = process.env.REPLICATOR_SECRET_ACCESS_KEY || ''
-const REPLICATOR_REGION = process.env.REPLICATOR_REGION || 'global'
-const REPLICATOR_DUDEWHERE_BUCKET_NAME =
-  process.env.REPLICATOR_DUDEWHERE_BUCKET_NAME || ''
-const REPLICATOR_ENDPOINT = process.env.REPLICATOR_ENDPOINT || ``
+const R2_ACCESS_KEY_ID = process.env.R2_ACCESS_KEY_ID || ''
+const R2_SECRET_ACCESS_KEY = process.env.R2_SECRET_ACCESS_KEY || ''
+const R2_REGION = process.env.R2_REGION || 'global'
+const R2_DUDEWHERE_BUCKET_NAME =
+  process.env.R2_DUDEWHERE_BUCKET_NAME || ''
+const R2_ENDPOINT = process.env.R2_ENDPOINT || ``
 
 /**
  * AWS HTTP Gateway handler for POST / with ucan invocation router.
@@ -53,13 +53,13 @@ async function ucanInvocationRouter (request) {
     }),
     carStoreBucket: createCarStore(AWS_REGION, storeBucketName),
     dudewhereBucket: createDudewhereStore(
-      REPLICATOR_REGION,
-      REPLICATOR_DUDEWHERE_BUCKET_NAME,
+      R2_REGION,
+      R2_DUDEWHERE_BUCKET_NAME,
       {
-        endpoint: REPLICATOR_ENDPOINT,
+        endpoint: R2_ENDPOINT,
         credentials: {
-          accessKeyId: REPLICATOR_ACCESS_KEY_ID,
-          secretAccessKey: REPLICATOR_SECRET_ACCESS_KEY,
+          accessKeyId: R2_ACCESS_KEY_ID,
+          secretAccessKey: R2_SECRET_ACCESS_KEY,
         },
       }
     ),

--- a/stacks/replicator-stack.js
+++ b/stacks/replicator-stack.js
@@ -26,11 +26,11 @@ export function ReplicatorStack({ stack }) {
     'carpark-replicator-handler',
     {
       environment: {
-        REPLICATOR_ACCESS_KEY_ID: process.env.REPLICATOR_ACCESS_KEY_ID || '',
-        REPLICATOR_ENDPOINT: process.env.REPLICATOR_ENDPOINT || '',
+        REPLICATOR_ACCESS_KEY_ID: process.env.R2_ACCESS_KEY_ID || '',
+        REPLICATOR_ENDPOINT: process.env.R2_ENDPOINT || '',
         REPLICATOR_SECRET_ACCESS_KEY:
-          process.env.REPLICATOR_SECRET_ACCESS_KEY || '',
-        REPLICATOR_BUCKET_NAME: process.env.REPLICATOR_CAR_BUCKET_NAME || '',
+          process.env.R2_SECRET_ACCESS_KEY || '',
+        REPLICATOR_BUCKET_NAME: process.env.R2_CAR_BUCKET_NAME || '',
       },
       permissions: ['s3:*'],
       handler: 'functions/replicator.handler',
@@ -44,11 +44,11 @@ export function ReplicatorStack({ stack }) {
     'satnav-replicator-handler',
     {
       environment: {
-        REPLICATOR_ACCESS_KEY_ID: process.env.REPLICATOR_ACCESS_KEY_ID || '',
-        REPLICATOR_ENDPOINT: process.env.REPLICATOR_ENDPOINT || '',
+        REPLICATOR_ACCESS_KEY_ID: process.env.R2_ACCESS_KEY_ID || '',
+        REPLICATOR_ENDPOINT: process.env.R2_ENDPOINT || '',
         REPLICATOR_SECRET_ACCESS_KEY:
-          process.env.REPLICATOR_SECRET_ACCESS_KEY || '',
-        REPLICATOR_BUCKET_NAME: process.env.REPLICATOR_INDEX_BUCKET_NAME || '',
+          process.env.R2_SECRET_ACCESS_KEY || '',
+        REPLICATOR_BUCKET_NAME: process.env.R2_SATNAV_BUCKET_NAME || '',
       },
       permissions: ['s3:*'],
       handler: 'functions/replicator.handler',

--- a/stacks/replicator-stack.js
+++ b/stacks/replicator-stack.js
@@ -30,7 +30,7 @@ export function ReplicatorStack({ stack }) {
         REPLICATOR_ENDPOINT: process.env.R2_ENDPOINT || '',
         REPLICATOR_SECRET_ACCESS_KEY:
           process.env.R2_SECRET_ACCESS_KEY || '',
-        REPLICATOR_BUCKET_NAME: process.env.R2_CAR_BUCKET_NAME || '',
+        REPLICATOR_BUCKET_NAME: process.env.R2_CARPARK_BUCKET_NAME || '',
       },
       permissions: ['s3:*'],
       handler: 'functions/replicator.handler',

--- a/stacks/replicator-stack.js
+++ b/stacks/replicator-stack.js
@@ -26,8 +26,8 @@ export function ReplicatorStack({ stack }) {
     'carpark-replicator-handler',
     {
       environment: {
-        REPLICATOR_ACCOUNT_ID: process.env.REPLICATOR_ACCOUNT_ID || '',
         REPLICATOR_ACCESS_KEY_ID: process.env.REPLICATOR_ACCESS_KEY_ID || '',
+        REPLICATOR_ENDPOINT: process.env.REPLICATOR_ENDPOINT || '',
         REPLICATOR_SECRET_ACCESS_KEY:
           process.env.REPLICATOR_SECRET_ACCESS_KEY || '',
         REPLICATOR_BUCKET_NAME: process.env.REPLICATOR_CAR_BUCKET_NAME || '',
@@ -44,8 +44,8 @@ export function ReplicatorStack({ stack }) {
     'satnav-replicator-handler',
     {
       environment: {
-        REPLICATOR_ACCOUNT_ID: process.env.REPLICATOR_ACCOUNT_ID || '',
         REPLICATOR_ACCESS_KEY_ID: process.env.REPLICATOR_ACCESS_KEY_ID || '',
+        REPLICATOR_ENDPOINT: process.env.REPLICATOR_ENDPOINT || '',
         REPLICATOR_SECRET_ACCESS_KEY:
           process.env.REPLICATOR_SECRET_ACCESS_KEY || '',
         REPLICATOR_BUCKET_NAME: process.env.REPLICATOR_INDEX_BUCKET_NAME || '',

--- a/stacks/satnav-stack.js
+++ b/stacks/satnav-stack.js
@@ -37,7 +37,7 @@ export function SatnavStack({ stack }) {
     'satnav-writer-handler',
     {
       environment : {
-
+        SATNAV_BUCKET_NAME: satnavBucket.bucketName
       },
       permissions: [satnavBucket, carparkBucket],
       handler: 'functions/satnav-writer.handler',


### PR DESCRIPTION
Adds env variables to the docs. Meanwhile discovered two issues with env variables:
- last replicator PR start using new pattern with `REPLICATOR_ENDPOINT` instead of `REPLICATOR_ACCOUNT_ID`. It is used already in lambda invoked https://github.com/web3-storage/upload-api/blob/main/replicator/functions/replicator.js#L15
- SATNAV_BUCKET_NAME was being injected in ENV Vars, but we don't need it anymore with latest refactors. We can just pass bucketName from reference.

TODO:
- [ ] Post Merge, remove OLD ENV VARs from build