### PR TITLE
fix: add sentry exception to ucanto server catch

### DIFF
--- a/api/service/index.js
+++ b/api/service/index.js
@@ -1,9 +1,15 @@
 import * as Server from '@ucanto/server'
 import * as CAR from '@ucanto/transport/car'
 import * as CBOR from '@ucanto/transport/cbor'
+import * as Sentry from '@sentry/serverless'
 
 import { createStoreService } from './store/index.js'
 import { createUploadService } from './upload/index.js'
+
+Sentry.AWSLambda.init({
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+})
 
 /**
  * @param {import('./types').UcantoServerContext} context
@@ -27,8 +33,8 @@ export function createServiceRouter (context) {
     decoder: CAR,
     service: createServiceRouter(context),
     catch: (/** @type {string | Error} */ err) => {
-      // TODO: We need sentry to log stuff
-      console.log('reporting error to sentry', err)
+      console.warn(err)
+      Sentry.AWSLambda.captureException(err)
     },
   })
 


### PR DESCRIPTION
This was missing from #59 and errors happening within ucanto service were not being propagated to sentry