### PR TITLE
fix: make carpark cors again

### DIFF
--- a/stacks/carpark-stack.js
+++ b/stacks/carpark-stack.js
@@ -28,6 +28,7 @@ export function CarparkStack({ stack, app }) {
   const { eventBus } = use(BusStack)
 
   const carparkBucket = new Bucket(stack, 'car-store', {
+    cors: true,
     ...stackConfig.carparkBucketConfig,
   })
 


### PR DESCRIPTION
> I get an upload URL! ...but
> `Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://carpark-staging-0.s3.us-east-2.amazonaws.com/`

Add CORS config to carpark bucket to allow uploads via signed URLs.

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>